### PR TITLE
Error messages with the registration service for publishing dataset.

### DIFF
--- a/src/main/java/Bundle.properties
+++ b/src/main/java/Bundle.properties
@@ -1021,6 +1021,9 @@ dataset.share.datasetShare=Share Dataset
 dataset.share.datasetShare.tip=Share this dataset on your favorite social media networks.
 dataset.share.datasetShare.shareText=View this dataset.
 dataset.publish.error.datacite=This dataset may not be published because the <a href=\"http://status.datacite.org/\" title=\"DataCite Status Page\" target=\"_blank\"/>DataCite Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
+dataset.publish.error.DataCiteException=This dataset may not be published because the <a href=\"http://status.datacite.org/\" title=\"DataCite Status Page\" target=\"_blank\"/>DataCite Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
+dataset.publish.error.HandleException=This dataset may not be published because the <a href=\"https://hdl.handle.net/\" title=\"handle proxy \" target=\"_blank\"/>Handle.net Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
+dataset.publish.error.EZIDException=This dataset may not be published because the <a href=\"http://ezid.lib.purdue.edu/contact/\" title=\"ezid contact Page\" target=\"_blank\"/>EZID Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
 dataset.publish.error.doi=This dataset may not be published because the DOI update failed.
 dataset.delete.error.datacite=Could not deaccession the dataset because the DOI update failed.
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -97,8 +97,8 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
                         }
                     }
                 } catch (Throwable e) {
-                    // TODO add a variant for EZId
-                    throw new CommandException(ResourceBundle.getBundle("Bundle").getString("dataset.publish.error.datacite"), this);
+                    String exceptionName=e.getClass().getSimpleName();
+                    throw new CommandException(ResourceBundle.getBundle("Bundle").getString("dataset.publish.error."+exceptionName), this);
                 }
             } else {
                 throw new IllegalCommandException("This dataset may not be published because its id registry service is not supported.", this);
@@ -220,9 +220,12 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
         }
 
         if (idServiceBean!= null && !idServiceBean.registerWhenPublished())
-            if (!idServiceBean.publicizeIdentifier(savedDataset))
-                throw new CommandException(ResourceBundle.getBundle("Bundle").getString("dataset.publish.error.datacite"), this);
-
+            try{
+                idServiceBean.publicizeIdentifier(savedDataset);
+            }catch (Throwable e) {
+                String exceptionName=e.getClass().getSimpleName();
+                throw new CommandException(ResourceBundle.getBundle("Bundle").getString("dataset.publish.error."+exceptionName), this);
+            }
         PrivateUrl privateUrl = ctxt.engine().submit(new GetPrivateUrlCommand(getRequest(), savedDataset));
         if (privateUrl != null) {
             logger.fine("Deleting Private URL for dataset id " + savedDataset.getId());


### PR DESCRIPTION
Changed explicit calling of Datacite related error to generic message with  the name of registration service being used.

### 1. Related Issues

- #2437 + Handles: Restore handle registration functionality in 4.x]
- Solution for Keven's point 

> Make Error messages generalized. The message reads "Datacite," but instead should show the registration service being used.

---
### 2. Pull Request Checklist

- [ ]  Functionality completed as described in FRD
- [ ]  Dependencies, risks, assumptions in FRD addressed
- [ ]  Unit tests completed
- [ ]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [ ]  Documentation completed
- [ ]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts
