### PR TITLE
Bundle items with variable, and additional method to get provider's name

### DIFF
--- a/src/main/java/Bundle.properties
+++ b/src/main/java/Bundle.properties
@@ -1020,10 +1020,7 @@ dataset.email.datasetLinkBtn.tip=Link Dataset to Your Dataverse
 dataset.share.datasetShare=Share Dataset
 dataset.share.datasetShare.tip=Share this dataset on your favorite social media networks.
 dataset.share.datasetShare.shareText=View this dataset.
-dataset.publish.error.datacite=This dataset may not be published because the <a href=\"http://status.datacite.org/\" title=\"DataCite Status Page\" target=\"_blank\"/>DataCite Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
-dataset.publish.error.DataCiteException=This dataset may not be published because the <a href=\"http://status.datacite.org/\" title=\"DataCite Status Page\" target=\"_blank\"/>DataCite Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
-dataset.publish.error.HandleException=This dataset may not be published because the <a href=\"https://hdl.handle.net/\" title=\"handle proxy \" target=\"_blank\"/>Handle.net Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
-dataset.publish.error.EZIDException=This dataset may not be published because the <a href=\"http://ezid.lib.purdue.edu/contact/\" title=\"ezid contact Page\" target=\"_blank\"/>EZID Service</a> is currently inaccessible. Please try again. Does the issue continue to persist?
+dataset.publish.error=This dataset may not be published because the <a href=\{1} target=\"_blank\"/> {0} </a> Service  is currently inaccessible. Please try again. Does the issue continue to persist?
 dataset.publish.error.doi=This dataset may not be published because the DOI update failed.
 dataset.delete.error.datacite=Could not deaccession the dataset because the DOI update failed.
 

--- a/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIDataCiteServiceBean.java
@@ -5,7 +5,9 @@
  */
 package edu.harvard.iq.dataverse;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
@@ -237,5 +239,15 @@ public class DOIDataCiteServiceBean extends AbstractIdServiceBean {
             logger.log(Level.WARNING, "message {0}", e.getMessage());
             return false;
         }
+    }
+    
+    @Override
+    public List<String> getProviderInformation(){
+        ArrayList <String> providerInfo = new ArrayList<>();
+        String providerName = "DataCite";
+        String providerLink = "http://status.datacite.org";
+        providerInfo.add(providerName);
+        providerInfo.add(providerLink);
+        return providerInfo;
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/DOIEZIdServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DOIEZIdServiceBean.java
@@ -7,8 +7,10 @@ package edu.harvard.iq.dataverse;
 
 import edu.ucsb.nceas.ezid.EZIDException;
 import edu.ucsb.nceas.ezid.EZIDService;
+import java.util.ArrayList;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
@@ -228,4 +230,15 @@ public class DOIEZIdServiceBean extends AbstractIdServiceBean {
         }
         
     }
+    
+    @Override
+    public List<String> getProviderInformation(){
+        ArrayList <String> providerInfo = new ArrayList<>();
+        String providerName = "EZID";
+        String providerLink = baseURLString;
+        providerInfo.add(providerName);
+        providerInfo.add(providerLink);
+        return providerInfo;
+    }
 }
+

--- a/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
@@ -251,7 +251,7 @@ public class HandlenetServiceBean extends AbstractIdServiceBean {
                 + "/" + dataset.getIdentifier();  
         return targetUrl;
     }
-    
+ 
     public String getSiteUrl() {
         logger.log(Level.FINE,"getSiteUrl");
         String hostUrl = System.getProperty("dataverse.siteUrl");
@@ -405,6 +405,16 @@ public class HandlenetServiceBean extends AbstractIdServiceBean {
     private String getAuthHandle(Dataset datasetIn) {
         // TODO hack: GNRSServiceBean retrieved this from vdcNetworkService
         return "0.NA/" + datasetIn.getAuthority();
+    }
+    
+    @Override
+    public List<String> getProviderInformation(){
+        ArrayList <String> providerInfo = new ArrayList<>();
+        String providerName = "Handle";
+        String providerLink = "https://hdl.handle.net";
+        providerInfo.add(providerName);
+        providerInfo.add(providerLink);
+        return providerInfo;
     }
 }
 

--- a/src/main/java/edu/harvard/iq/dataverse/IdServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/IdServiceBean.java
@@ -15,6 +15,8 @@ public interface IdServiceBean {
     boolean alreadyExists(Dataset dataset) throws Exception;
 
     boolean registerWhenPublished();
+    
+    List<String> getProviderInformation();
 
     String createIdentifier(Dataset dataset) throws Throwable;
 

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -19,6 +19,7 @@ import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
 import edu.harvard.iq.dataverse.search.IndexResponse;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
+import edu.harvard.iq.dataverse.util.BundleUtil;
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.jsonAsDatasetDto;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -97,8 +98,7 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
                         }
                     }
                 } catch (Throwable e) {
-                    String exceptionName=e.getClass().getSimpleName();
-                    throw new CommandException(ResourceBundle.getBundle("Bundle").getString("dataset.publish.error."+exceptionName), this);
+                    throw new CommandException(BundleUtil.getStringFromBundle("dataset.publish.error", idServiceBean.getProviderInformation()),this); 
                 }
             } else {
                 throw new IllegalCommandException("This dataset may not be published because its id registry service is not supported.", this);
@@ -223,8 +223,7 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
             try{
                 idServiceBean.publicizeIdentifier(savedDataset);
             }catch (Throwable e) {
-                String exceptionName=e.getClass().getSimpleName();
-                throw new CommandException(ResourceBundle.getBundle("Bundle").getString("dataset.publish.error."+exceptionName), this);
+                throw new CommandException(BundleUtil.getStringFromBundle("dataset.publish.error", idServiceBean.getProviderInformation()),this); 
             }
         PrivateUrl privateUrl = ctxt.engine().submit(new GetPrivateUrlCommand(getRequest(), savedDataset));
         if (privateUrl != null) {
@@ -248,6 +247,6 @@ public class PublishDatasetCommand extends AbstractCommand<Dataset> {
         IndexResponse indexResponse = ctxt.solrIndex().indexPermissionsForOneDvObject(savedDataset);
 
         return savedDataset;
-    }
+    }    
 
 }


### PR DESCRIPTION
Minimized the number of bundle items of dataset publish message.
Method added into each implementation to return its own name and service provider's link

# RFI Checklist

### 1. Related Issues

_for the issue [#2437](https://github.com/IQSS/dataverse/issues/2437)

-Handles: Restore handle registration functionality in 4.x

---
### 2. Pull Request Checklist

- [ ]  Functionality completed as described in FRD
- [ ]  Dependencies, risks, assumptions in FRD addressed
- [ ]  Unit tests completed
- [ ]  Deployment requirements identified (e.g., SQL scripts, indexing)
- [ ]  Documentation completed
- [ ]  All code checkins completed

---
### 3. Review Checklist

_**After** the pull request has been submitted, fill out this section._

- [ ]  Code review completed or waived
- [ ]  Testing requirements completed
- [ ]  Usability testing completed or waived
- [ ]  Support testing completed or waived
- [ ]  Merged with develop branch and resolved conflicts
