### PR TITLE
DDN-253 Handle Migration - register without connection to the GHR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ michael-local
 GPATH
 GTAGS
 GRTAGS
+.idea
+*.iml
 # OS generated files #
 ######################
 .DS_Store

--- a/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/HandlenetServiceBean.java
@@ -320,7 +320,9 @@ public class HandlenetServiceBean extends AbstractIdServiceBean {
     
     private String getHandleAuthority(String handlePrefix) {
         logger.log(Level.FINE,"getHandleAuthority");
-        return "0.NA/" + handlePrefix;
+        // Authority Handle, depends on Handleservice setup
+        // Default Handle install has 0.NA/<prefix> but for 'independent service' config it is <prefix>/ADMIN
+        return handlePrefix + "/ADMIN";
     }
 
     @Override
@@ -404,7 +406,7 @@ public class HandlenetServiceBean extends AbstractIdServiceBean {
 
     private String getAuthHandle(Dataset datasetIn) {
         // TODO hack: GNRSServiceBean retrieved this from vdcNetworkService
-        return "0.NA/" + datasetIn.getAuthority();
+        return getHandleAuthority(datasetIn.getAuthority());
     }
     
     @Override


### PR DESCRIPTION
For the Handle Migration we want to be able to register handles without communication with the Global Handle Registry. 
Then we can have Dataverse.nl working behind our firewall without opening ports.  

For this to work, our Local Handle Registry needs to be reconfigured to authenticate using the handle prefix/ADMIN instead of 0.NA/prefix. Where prefix is the number that we register at Handle.Net; 10695 for testing and acceptance.  

To test this PR, build the war and deploy on  glassfish. 
But before doing that the Handle service needs to reconfigured according to the Technical Manual section 10. 
You should be able to 'publish' a dataset with a handle while you have all network connections disabled. To check that the just registered handle is indeed in the registry run the listing and see that it is in there: 
 
`
$ bin/hdl-list 10695/ADMIN 300 /usr/local/handle/svr_1/admpriv.bin 10695 
`

Make sure that the user running this script also has the correct .handle dir and that the admpriv.bin file is correct. 
  