### PR TITLE
Fix too many open files problem

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/ExportService.java
@@ -262,7 +262,7 @@ public class ExportService {
                     exporter.exportDataset(version, datasetAsJson, cachedExportOutputStream);
                     cachedExportOutputStream.flush();
                     cachedExportOutputStream.close();
-
+                    outputStream.close();
                 } else {
                     // this method copies a local filesystem Path into this DataAccess Auxiliary location:
                     exporter.exportDataset(version, datasetAsJson, outputStream);

--- a/src/main/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/export/SchemaDotOrgExporter.java
@@ -22,18 +22,18 @@ public class SchemaDotOrgExporter implements Exporter {
     @Override
     public void exportDataset(DatasetVersion version, JsonObject json, OutputStream outputStream) throws ExportException {
         String jsonLdAsString = version.getJsonLd();
-        StringReader stringReader = new StringReader(jsonLdAsString);
-        JsonReader jsonReader = Json.createReader(stringReader);
-        JsonObject jsonLdJsonObject = jsonReader.readObject();
-        try {
-            outputStream.write(jsonLdJsonObject.toString().getBytes("UTF8"));
-        } catch (IOException ex) {
-            logger.info("IOException calling outputStream.write: " + ex);
-        }
-        try {
-            outputStream.flush();
-        } catch (IOException ex) {
-            logger.info("IOException calling outputStream.flush: " + ex);
+        try (JsonReader jsonReader = Json.createReader(new StringReader(jsonLdAsString));) {
+            JsonObject jsonLdJsonObject = jsonReader.readObject();
+            try {
+                outputStream.write(jsonLdJsonObject.toString().getBytes("UTF8"));
+            } catch (IOException ex) {
+                logger.info("IOException calling outputStream.write: " + ex);
+            }
+            try {
+                outputStream.flush();
+            } catch (IOException ex) {
+                logger.info("IOException calling outputStream.flush: " + ex);
+            }
         }
     }
 


### PR DESCRIPTION
Backport of two code changes from harvard, to fix that files are not close in metadata export. 

Two known file descriptor leaks in Dataverse 4.8.6 Export code. 
close outputStream on local storage #4654
https://github.com/IQSS/dataverse/pull/4654
and
4669 schema dot org exporter #4673
SchemaDotOrgExporter.java doesn't close jsonReader #4669 
https://github.com/IQSS/dataverse/pull/4673
