### PR TITLE
Fix problem where pressing tab skips some fields.

### DIFF
--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -35,13 +35,13 @@
     </ui:fragment>
     <ui:fragment rendered="#{displayCV and dsfv.datasetField.datasetFieldType.name==cvMgr.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[1]}">
         <div id="akmi_#{valCount.index+1}_#{cvMgr.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[1]}">
-            <p:inputText value="#{dsfv.valueForEdit}" id="cv_term_#{valCount.index+1}" tabindex="#{block.index+1}"
+            <p:inputText value="#{dsfv.valueForEdit}" id="cv_term_#{valCount.index+1}"
                          styleClass="form-control #{dsfv.datasetField.datasetFieldType.name == 'title' and DatasetPage.editMode == 'CREATE'  ? 'datasetfield-title' : ''}"/>
         </div>
     </ui:fragment>
     <ui:fragment rendered="#{displayCV and dsfv.datasetField.datasetFieldType.name==cvMgr.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[2] }">
         <div id="akmi_#{valCount.index+1}_#{cvMgr.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[2]}">
-            <p:inputText value="#{dsfv.valueForEdit}" id="cv_url_#{valCount.index+1}" tabindex="#{block.index+1}"
+            <p:inputText value="#{dsfv.valueForEdit}" id="cv_url_#{valCount.index+1}"
                          styleClass="form-control #{dsfv.datasetField.datasetFieldType.name == 'title' and DatasetPage.editMode == 'CREATE'  ? 'datasetfield-title' : ''}"/>
         </div>
         <script src="#{cvMgr.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getJsUrl()}">


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the problem in the UI where pressing tab skips some input fields.

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: Run dev_archaeology and press tab on all the fields in the Temporal (ABR Period)  section.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: No

**Is there a release notes update needed for this change?**: No

**Additional documentation**: No
