### PR TITLE
DD-377 Improving the cvoc metadata term selection input

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5461,6 +5461,9 @@ public class DatasetPage implements Serializable {
                 if (jo.containsKey("readonly") && jo.getString("readonly").toLowerCase().equals("true"))
                     cvocReadonly = true;
                 logger.fine("cvoc - readonly: " + cvocReadonly);
+                int cvocMinChars = 0;
+                if (jo.containsKey("minChars") && jo.getInt("minChars") >= 0)
+                    cvocMinChars = jo.getInt("minChars");
                 String cvocProtocol = "skosmos";//default
                 if (jo.containsKey("protocol"))
                     cvocProtocol = jo.getString("protocol");
@@ -5485,7 +5488,7 @@ public class DatasetPage implements Serializable {
                 if (jo.containsKey("cvoc-url"))
                     cvocUrl = jo.getString("cvoc-url");
                 logger.fine("cvoc - cvoc-url: " + cvocUrl);
-                CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocTermParentUri, cvocReadonly, vocabsList, vocabCodesList
+                CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocTermParentUri, cvocReadonly, cvocMinChars, vocabsList, vocabCodesList
                         , cvocJsUrl, cvocMapId, cvocMapQuery);
                 cvocMap.put(jo.getString("vocab-name"), cvoc);
 
@@ -5502,14 +5505,16 @@ public class DatasetPage implements Serializable {
         String mapId;
         String mapQuery;
         boolean readonly;
+        int minChars;
         List<String> vocabs;
         List<String> keys;
-        public CVoc(String cvocUrl, String language, String protocol, String termParentUri, boolean readonly,
+        public CVoc(String cvocUrl, String language, String protocol, String termParentUri, boolean readonly, int minChars,
                     List<String> vocabs, List<String> keys, String jsUrl, String mapId, String mapQuery){
             this.cvocUrl = cvocUrl;
             this.language = language;
             this.protocol = protocol;
             this.readonly = readonly;
+            this.minChars = minChars;
             this.vocabs = vocabs;
             this.termParentUri = termParentUri;
             this.keys = keys;
@@ -5531,6 +5536,7 @@ public class DatasetPage implements Serializable {
         public boolean isReadonly() {
             return readonly;
         }
+        public int getMinChars() { return minChars; }
         public List<String> getVocabs() {
             return vocabs;
         }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5464,6 +5464,7 @@ public class DatasetPage implements Serializable {
                 int cvocMinChars = 0;
                 if (jo.containsKey("minChars") && jo.getInt("minChars") >= 0)
                     cvocMinChars = jo.getInt("minChars");
+                logger.fine("cvoc - minChars: " + cvocMinChars);
                 String cvocProtocol = "skosmos";//default
                 if (jo.containsKey("protocol"))
                     cvocProtocol = jo.getString("protocol");
@@ -5491,7 +5492,6 @@ public class DatasetPage implements Serializable {
                 CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocTermParentUri, cvocReadonly, cvocMinChars, vocabsList, vocabCodesList
                         , cvocJsUrl, cvocMapId, cvocMapQuery);
                 cvocMap.put(jo.getString("vocab-name"), cvoc);
-
             }
         }
         return cvocMap;

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5461,6 +5461,10 @@ public class DatasetPage implements Serializable {
                 if (jo.containsKey("readonly") && jo.getString("readonly").toLowerCase().equals("true"))
                     cvocReadonly = true;
                 logger.fine("cvoc - readonly: " + cvocReadonly);
+                boolean cvocHideReadonlyUrls = false;
+                if (jo.containsKey("hideReadonlyUrls") && jo.getString("hideReadonlyUrls").toLowerCase().equals("true"))
+                    cvocHideReadonlyUrls = true;
+                logger.fine("cvoc - cvocHideReadonlyUrls: " + cvocHideReadonlyUrls);
                 int cvocMinChars = 0;
                 if (jo.containsKey("minChars") && jo.getInt("minChars") >= 0)
                     cvocMinChars = jo.getInt("minChars");
@@ -5489,7 +5493,7 @@ public class DatasetPage implements Serializable {
                 if (jo.containsKey("cvoc-url"))
                     cvocUrl = jo.getString("cvoc-url");
                 logger.fine("cvoc - cvoc-url: " + cvocUrl);
-                CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocTermParentUri, cvocReadonly, cvocMinChars, vocabsList, vocabCodesList
+                CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocTermParentUri, cvocReadonly, cvocHideReadonlyUrls, cvocMinChars, vocabsList, vocabCodesList
                         , cvocJsUrl, cvocMapId, cvocMapQuery);
                 cvocMap.put(jo.getString("vocab-name"), cvoc);
             }
@@ -5505,15 +5509,17 @@ public class DatasetPage implements Serializable {
         String mapId;
         String mapQuery;
         boolean readonly;
+        boolean hideReadonlyUrls;
         int minChars;
         List<String> vocabs;
         List<String> keys;
-        public CVoc(String cvocUrl, String language, String protocol, String termParentUri, boolean readonly, int minChars,
+        public CVoc(String cvocUrl, String language, String protocol, String termParentUri, boolean readonly, boolean hideReadonlyUrls, int minChars,
                     List<String> vocabs, List<String> keys, String jsUrl, String mapId, String mapQuery){
             this.cvocUrl = cvocUrl;
             this.language = language;
             this.protocol = protocol;
             this.readonly = readonly;
+            this.hideReadonlyUrls = hideReadonlyUrls;
             this.minChars = minChars;
             this.vocabs = vocabs;
             this.termParentUri = termParentUri;
@@ -5535,6 +5541,9 @@ public class DatasetPage implements Serializable {
         }
         public boolean isReadonly() {
             return readonly;
+        }
+        public boolean isHideReadonlyUrls() {
+            return hideReadonlyUrls;
         }
         public int getMinChars() { return minChars; }
         public List<String> getVocabs() {

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -81,7 +81,7 @@
                             cv = { 'cvocUrl' : cvocUrl, 'protocol': cvocProtocol, 'lang': cvocLang, 'termParentUri': termParentUri, 'selectedVocab': selectedVocab, 'term': request.term };
                         autointerface(request, response, cv, mapping);
                           },
-                          minLength: 1,
+                          minLength: #{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getMinChars()},
                           select: function(event, ui) {
                                $.each(ui, function(i, v) {
                                $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[2]}").find("input[name*='cv_url_']").val(v.id);

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -49,6 +49,7 @@
         <script src="#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getJsUrl()}">
         </script>
         <script>
+        //<![CDATA[
                 $(document).ready(function() {
                     var jsonResult = {};
                     var cvocUrl = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getCVocUrl()}";
@@ -56,14 +57,24 @@
                     var cvocProtocol = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getProtocol()}";
                     var termParentUri ="#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getTermParentUri()}";
                     var vocabsize = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getVocabs().size()}";
-                    var readonly = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isReadonly()}";
+                    var readonly = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isReadonly()}" === "true";
+                    var hideReadonlyUrls = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isHideReadonlyUrls()}" === "true";
                     //$("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").css('background-color' , '#EEEEEE');
                     $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").val(termParentUri);
-                    if (vocabsize == 1 &amp;&amp; readonly)
+                    if (vocabsize == 1 && readonly) {
+                        // make it look readonly
                         $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[0]}").find("input[name*='cv_vocabs_'").css('background-color' , '#EEEEEE');
+                        // Note that we could decide to not display this at all
+                        //$("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[0]}").parent().css('display' , 'none');
+                    }
+                    if (readonly && hideReadonlyUrls) {
+                        // do not display URL fields and their labels
+                        $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[2]}").parent().css('display' , 'none');
+                        $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").parent().css('display' , 'none');
+                    }
                     var selectedVocab = "";
                     var vocabFieldValue = $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[0]}").find("input[name*='cv_vocabs_'").val();
-                    if (vocabFieldValue =='' &amp;&amp; vocabsize == 1) {
+                    if (vocabFieldValue =='' && vocabsize == 1) {
                             selectedVocab = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getVocabs()[0]}";
                             $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[0]}").find("input[name*='cv_vocabs_'").val(selectedVocab);
                     }
@@ -90,6 +101,7 @@
                         }
                     );
                  });
+            //]]>
             </script>
         <style type="text/css">
             ul.ui-autocomplete {


### PR DESCRIPTION
**What this PR does / why we need it**:
The cvoc metadata term selection input should show all possible input in the dropdown without any characters typed for autocomplete
Added are the minChars config option and the hideReadonlyUrls option. 
The minChars is 0 by default, resulting in a terms dropdown without any character input, just by typing the up or down arrow keys in the input field. 
Using hideReadonlyUrls, which is false by default, you can hide the URL files if they are also readonly. T

**Which issue(s) this PR closes**:
Closes #DD-377

**Special notes for your reviewer**:

**Suggestions on how to test this**:
change the config json for the cvocs and have it use the new options:
  "readonly": "true",
  "hideReadonlyUrls": "true",
  "minChars": "1",

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
![Screenshot 2021-03-02 at 10 47 53 (2)](https://user-images.githubusercontent.com/2151103/109630339-14642780-7b45-11eb-972c-64eddfff4adf.png)

Complex is showing the URLs, but Period is not.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
