### PR TITLE
Added ajax loading indicator css for the external cvoc autocomplete input field

### DIFF
--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -116,6 +116,9 @@
                 /* add padding to account for vertical scrollbar */
                 padding-right: 20px;
             }
+            input[type='text'].ui-autocomplete-loading {
+                background: url('/resources/images/ajax-loading.gif') no-repeat right center;
+            }
         </style>
     </ui:fragment>
     <ui:fragment rendered="#{displayCV and dsfv.datasetField.datasetFieldType.name==cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}">


### PR DESCRIPTION
Shows a 'spinner' image indicating that something is being 'loaded' on the autocomplete cvoc input field. 
This is useful because it can take several seconds before the dropdown is populated on the Ajax request. The response depends on the external service, so might even be slower if there is much network traffic. 

This is related to issue https://drivenbydata.atlassian.net/browse/DD-377
