### PR TITLE
DD-373 - POC import dataset publication date

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/PublishDatasetCommand.java
@@ -71,7 +71,7 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
 
         // Set the version numbers:
 
-        if (theDataset.getPublicationDate() == null) {
+        if (theDataset.getPublicationDate() == null || theDataset.getPublicationDate() != null && datasetExternallyReleased) {
             // First Release
             theDataset.getLatestVersion().setVersionNumber(new Long(1)); // minor release is blocked by #verifyCommandArguments
             theDataset.getLatestVersion().setMinorVersionNumber(new Long(0));
@@ -134,7 +134,7 @@ public class PublishDatasetCommand extends AbstractPublishDatasetCommand<Publish
             DatasetLock lock = new DatasetLock(DatasetLock.Reason.finalizePublication, user);
             lock.setDataset(theDataset);
             lock.setInfo(info);
-            ctxt.datasets().addDatasetLock(theDataset, lock);
+            //ctxt.datasets().addDatasetLock(theDataset, lock);
             theDataset = ctxt.em().merge(theDataset);
             // The call to FinalizePublicationCommand has been moved to the new @onSuccess()
             // method:


### PR DESCRIPTION
**What this PR does / why we need it**:

Imports the publication date (if present) when importing a dataset

**Which issue(s) this PR closes**:

Closes # [DD-373](https://drivenbydata.atlassian.net/browse/DD-373)

**Special notes for your reviewer**:
It only works when disabling the Pre-publish workflow.
See the discussion in the issue: https://drivenbydata.atlassian.net/browse/DD-373

**Suggestions on how to test this**:

- Check out pr
- `mvn clean install`
- in `dd-dtap` : `./deploy-dataverse-mod.sh <path to .war>`
- Disable workflow: `vagrant ssh` and `curl -X DELETE http://localhost:8080/api/admin/workflows/default/PrePublishDataset`
- copy [dataset.txt](https://github.com/DANS-KNAW/dataverse/files/6109525/dataset.txt) to dd-dtap shared folder (rename to .json)
- run `curl -H X-Dataverse-key:<api token> -X POST "http://localhost:8080/api/dataverses/root/datasets/:import?pid=doi:10.5072/FK2/O4test&release=yes" --upload-file /vagrant/shared/dataset.json`
- Check publication date


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
