### PR TITLE
DD-386: Uses the vocab-uri parameter from the cvoc config

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5489,11 +5489,15 @@ public class DatasetPage implements Serializable {
                 if (jo.containsKey("term-parent-uri"))
                     cvocTermParentUri = jo.getString("term-parent-uri");
                 logger.fine("cvoc - term-parent-uri: " + cvocTermParentUri);
+                String cvocVocabUri = "";
+                if (jo.containsKey("vocab-uri"))
+                    cvocVocabUri = jo.getString("vocab-uri");
+                logger.fine("cvoc - vocab-uri: " + cvocVocabUri);
                 String cvocUrl = "http://localhost/Skosmos";
                 if (jo.containsKey("cvoc-url"))
                     cvocUrl = jo.getString("cvoc-url");
                 logger.fine("cvoc - cvoc-url: " + cvocUrl);
-                CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocTermParentUri, cvocReadonly, cvocHideReadonlyUrls, cvocMinChars, vocabsList, vocabCodesList
+                CVoc cvoc = new CVoc(cvocUrl, cvocLang, cvocProtocol, cvocVocabUri, cvocTermParentUri, cvocReadonly, cvocHideReadonlyUrls, cvocMinChars, vocabsList, vocabCodesList
                         , cvocJsUrl, cvocMapId, cvocMapQuery);
                 cvocMap.put(jo.getString("vocab-name"), cvoc);
             }
@@ -5504,6 +5508,7 @@ public class DatasetPage implements Serializable {
         String cvocUrl;
         String language;
         String protocol;
+        String vocabUri;
         String termParentUri;
         String jsUrl;
         String mapId;
@@ -5513,7 +5518,7 @@ public class DatasetPage implements Serializable {
         int minChars;
         List<String> vocabs;
         List<String> keys;
-        public CVoc(String cvocUrl, String language, String protocol, String termParentUri, boolean readonly, boolean hideReadonlyUrls, int minChars,
+        public CVoc(String cvocUrl, String language, String protocol, String vocabUri, String termParentUri, boolean readonly, boolean hideReadonlyUrls, int minChars,
                     List<String> vocabs, List<String> keys, String jsUrl, String mapId, String mapQuery){
             this.cvocUrl = cvocUrl;
             this.language = language;
@@ -5522,6 +5527,7 @@ public class DatasetPage implements Serializable {
             this.hideReadonlyUrls = hideReadonlyUrls;
             this.minChars = minChars;
             this.vocabs = vocabs;
+            this.vocabUri = vocabUri;
             this.termParentUri = termParentUri;
             this.keys = keys;
             this.jsUrl = jsUrl;
@@ -5536,6 +5542,9 @@ public class DatasetPage implements Serializable {
             return language;
         }
         public String getProtocol() { return protocol; }
+        public String getVocabUri() {
+            return vocabUri;
+        }
         public String getTermParentUri() {
             return termParentUri;
         }

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -61,7 +61,7 @@
                     var readonly = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isReadonly()}" === "true";
                     var hideReadonlyUrls = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isHideReadonlyUrls()}" === "true";
                     //$("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").css('background-color' , '#EEEEEE');
-                    $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").val(vocabUri);//termParentUri);
+                    $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").val(vocabUri);
                     if (vocabsize == 1 && readonly) {
                         // make it look readonly
                         $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[0]}").find("input[name*='cv_vocabs_'").css('background-color' , '#EEEEEE');

--- a/src/main/webapp/datasetFieldForEditFragment.xhtml
+++ b/src/main/webapp/datasetFieldForEditFragment.xhtml
@@ -55,12 +55,13 @@
                     var cvocUrl = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getCVocUrl()}";
                     var cvocLang = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getLanguage()}";
                     var cvocProtocol = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getProtocol()}";
+                    var vocabUri ="#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getVocabUri()}";
                     var termParentUri ="#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getTermParentUri()}";
                     var vocabsize = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getVocabs().size()}";
                     var readonly = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isReadonly()}" === "true";
                     var hideReadonlyUrls = "#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).isHideReadonlyUrls()}" === "true";
                     //$("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").css('background-color' , '#EEEEEE');
-                    $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").val(termParentUri);
+                    $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[3]}").find("input[name*='cv_vocab_url_'").val(vocabUri);//termParentUri);
                     if (vocabsize == 1 && readonly) {
                         // make it look readonly
                         $("#akmi_#{valCount.index+1}_#{cvoc.get(dsfv.datasetField.datasetFieldType.parentDatasetFieldType.name).getKeys()[0]}").find("input[name*='cv_vocabs_'").css('background-color' , '#EEEEEE');


### PR DESCRIPTION
Uses the vocab-uri parameter from the cvoc config to store in the metadata

**What this PR does / why we need it**:
The parent uri  was being stored into the cvoc vocabulary URL input field, but that was not working for the Collecties cvoc, where we did not filter on a parent concept. 
So we needed to use the true vocabulary URI for the cvocs, even if we only used part of the vocabulary. 
This vocabulary URI is now extracted from the config; https://github.com/DANS-KNAW/dd-dtap/pull/94

**Which issue(s) this PR closes**:

Closes #DD-386

**Special notes for your reviewer**:

**Suggestions on how to test this**:
You need to have the updated config (from PR https://github.com/DANS-KNAW/dd-dtap/pull/94)
After building this war file you can deploy it with dd-dtap using; ./deploy-dataverse-mod.sh ../dataverse/target/dataverse-5.3.war

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
