### PR TITLE
DD-387 Add license entity and api

### DIFF
--- a/scripts/api/data/license.json
+++ b/scripts/api/data/license.json
@@ -1,0 +1,7 @@
+{
+  "name": "Apache License",
+  "shortDescription": "License description",
+  "uri": "www.apache.com",
+  "iconUrl": "www.icon.com",
+  "active": false
+}

--- a/scripts/api/data/license.json
+++ b/scripts/api/data/license.json
@@ -1,7 +1,7 @@
 {
-  "name": "Apache License",
-  "shortDescription": "License description",
-  "uri": "www.apache.com",
-  "iconUrl": "www.icon.com",
+  "name": "Apache License 1.0",
+  "shortDescription": "This is the original Apache License which applies only to very old versions of Apache packages (such as version 1.2 of the Web server).",
+  "uri": "https://www.apache.org/licenses/LICENSE-1.0",
+  "iconUrl": "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/rick-astley-1-1552336336.png",
   "active": false
 }

--- a/scripts/api/data/license.json
+++ b/scripts/api/data/license.json
@@ -2,6 +2,6 @@
   "name": "Apache License 1.0",
   "shortDescription": "This is the original Apache License which applies only to very old versions of Apache packages (such as version 1.2 of the Web server).",
   "uri": "https://www.apache.org/licenses/LICENSE-1.0",
-  "iconUrl": "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/rick-astley-1-1552336336.png",
+  "iconUrl": "https://itgala.xyz/wp-content/uploads/2017/10/Apache-HTTP-Server.png",
   "active": false
 }

--- a/scripts/api/data/licenseError.json
+++ b/scripts/api/data/licenseError.json
@@ -1,8 +1,8 @@
 {
   "id": 6,
-  "name": "Apache License",
-  "shortDescription": "License description",
-  "uri": "www.apache.com",
-  "iconUrl": "www.icon.com",
+  "name": "Apache License 1.0",
+  "shortDescription": "This is the original Apache License which applies only to very old versions of Apache packages (such as version 1.2 of the Web server).",
+  "uri": "https://www.apache.org/licenses/LICENSE-1.0",
+  "iconUrl": "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/rick-astley-1-1552336336.png",
   "active": false
 }

--- a/scripts/api/data/licenseError.json
+++ b/scripts/api/data/licenseError.json
@@ -1,0 +1,8 @@
+{
+  "id": 6,
+  "name": "Apache License",
+  "shortDescription": "License description",
+  "uri": "www.apache.com",
+  "iconUrl": "www.icon.com",
+  "active": false
+}

--- a/scripts/api/data/licenseError.json
+++ b/scripts/api/data/licenseError.json
@@ -3,6 +3,6 @@
   "name": "Apache License 1.0",
   "shortDescription": "This is the original Apache License which applies only to very old versions of Apache packages (such as version 1.2 of the Web server).",
   "uri": "https://www.apache.org/licenses/LICENSE-1.0",
-  "iconUrl": "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/rick-astley-1-1552336336.png",
+  "iconUrl": "https://itgala.xyz/wp-content/uploads/2017/10/Apache-HTTP-Server.png",
   "active": false
 }

--- a/scripts/api/data/licenseUpdate.json
+++ b/scripts/api/data/licenseUpdate.json
@@ -2,6 +2,6 @@
   "name": "Apache License 2.0",
   "shortDescription": "The 2.0 version of the Apache License, approved by the ASF in 2004.",
   "uri": "https://www.apache.org/licenses/LICENSE-2.0",
-  "iconUrl": "https://yt3.ggpht.com/ytc/AAUvwni36SveDisR-vOAmmklBfJxnnjuRG3ihzfrwEfORA=s900-c-k-c0x00ffffff-no-rj",
+  "iconUrl": "https://itgala.xyz/wp-content/uploads/2017/10/Apache-HTTP-Server.png",
   "active": true
 }

--- a/scripts/api/data/licenseUpdate.json
+++ b/scripts/api/data/licenseUpdate.json
@@ -1,0 +1,7 @@
+{
+  "name": "Updated Apache License",
+  "shortDescription": "Updated license description",
+  "uri": "www.update-apache.com",
+  "iconUrl": "www.update-icon.com",
+  "active": true
+}

--- a/scripts/api/data/licenseUpdate.json
+++ b/scripts/api/data/licenseUpdate.json
@@ -1,7 +1,7 @@
 {
-  "name": "Updated Apache License",
-  "shortDescription": "Updated license description",
-  "uri": "www.update-apache.com",
-  "iconUrl": "www.update-icon.com",
+  "name": "Apache License 2.0",
+  "shortDescription": "The 2.0 version of the Apache License, approved by the ASF in 2004.",
+  "uri": "https://www.apache.org/licenses/LICENSE-2.0",
+  "iconUrl": "https://yt3.ggpht.com/ytc/AAUvwni36SveDisR-vOAmmklBfJxnnjuRG3ihzfrwEfORA=s900-c-k-c0x00ffffff-no-rj",
   "active": true
 }

--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -1,7 +1,7 @@
 package edu.harvard.iq.dataverse;
 
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -21,9 +21,12 @@ import javax.persistence.UniqueConstraint;
                 query="SELECT l FROM License l"),
     @NamedQuery( name="License.findById",
             query = "SELECT l FROM License l WHERE l.id=:id"),
+    @NamedQuery( name="License.findByName",
+            query = "SELECT l FROM License l WHERE l.name=:name"),
     @NamedQuery( name="License.deleteById",
-                query="DELETE FROM License l WHERE l.id=:id")
-
+                query="DELETE FROM License l WHERE l.id=:id"),
+    @NamedQuery( name="License.deleteByName",
+                query="DELETE FROM License l WHERE l.name=:name")
 })
 @Entity
 @Table(uniqueConstraints = {
@@ -43,10 +46,10 @@ public class License {
     private String shortDescription;
 
     @Column(columnDefinition="TEXT", nullable = false)
-    private URI uri;
+    private String uri;
 
     @Column(columnDefinition="TEXT")
-    private URL iconUrl;
+    private String iconUrl;
 
     @Column(nullable = false)
     private boolean active;
@@ -54,11 +57,11 @@ public class License {
     public License() {
     }
 
-    public License(String name, String shortDescription, URI uri, URL iconUrl, boolean active) {
+    public License(String name, String shortDescription, URI uri, URI iconUrl, boolean active) {
         this.name = name;
         this.shortDescription = shortDescription;
-        this.uri = uri;
-        this.iconUrl = iconUrl;
+        this.uri = uri.toASCIIString();
+        this.iconUrl = iconUrl.toASCIIString();
         this.active = active;
     }
 
@@ -86,20 +89,20 @@ public class License {
         this.shortDescription = shortDescription;
     }
 
-    public URI getUri() {
-        return uri;
+    public URI getUri() throws URISyntaxException {
+        return new URI(uri);
     }
 
     public void setUri(URI uri) {
-        this.uri = uri;
+        this.uri = uri.toASCIIString();
     }
 
-    public URL getIconUrl() {
-        return iconUrl;
+    public URI getIconUrl() throws URISyntaxException {
+        return new URI(iconUrl);
     }
 
-    public void setIconUrl(URL iconUrl) {
-        this.iconUrl = iconUrl;
+    public void setIconUrl(URI iconUrl) {
+        this.iconUrl = iconUrl.toASCIIString();
     }
 
     public boolean isActive() {

--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -89,16 +89,24 @@ public class License {
         this.shortDescription = shortDescription;
     }
 
-    public URI getUri() throws URISyntaxException {
-        return new URI(uri);
+    public URI getUri() {
+        try {
+            return new URI(uri);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Incorrect URI in JSON");
+        }
     }
 
     public void setUri(URI uri) {
         this.uri = uri.toASCIIString();
     }
 
-    public URI getIconUrl() throws URISyntaxException {
-        return new URI(iconUrl);
+    public URI getIconUrl() {
+        try {
+            return new URI(iconUrl);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Incorrect URI in JSON");
+        }
     }
 
     public void setIconUrl(URI iconUrl) {

--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -1,5 +1,7 @@
 package edu.harvard.iq.dataverse;
 
+import java.net.URI;
+import java.net.URL;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -41,10 +43,10 @@ public class License {
     private String shortDescription;
 
     @Column(columnDefinition="TEXT", nullable = false)
-    private String uri;
+    private URI uri;
 
     @Column(columnDefinition="TEXT")
-    private String iconUrl;
+    private URL iconUrl;
 
     @Column(nullable = false)
     private boolean active;
@@ -52,7 +54,7 @@ public class License {
     public License() {
     }
 
-    public License(String name, String shortDescription, String uri, String iconUrl, boolean active) {
+    public License(String name, String shortDescription, URI uri, URL iconUrl, boolean active) {
         this.name = name;
         this.shortDescription = shortDescription;
         this.uri = uri;
@@ -84,19 +86,19 @@ public class License {
         this.shortDescription = shortDescription;
     }
 
-    public String getUri() {
+    public URI getUri() {
         return uri;
     }
 
-    public void setUri(String uri) {
+    public void setUri(URI uri) {
         this.uri = uri;
     }
 
-    public String getIconUrl() {
+    public URL getIconUrl() {
         return iconUrl;
     }
 
-    public void setIconUrl(String iconUrl) {
+    public void setIconUrl(URL iconUrl) {
         this.iconUrl = iconUrl;
     }
 
@@ -132,8 +134,8 @@ public class License {
                 "id=" + id +
                 ", name='" + name + '\'' +
                 ", shortDescription='" + shortDescription + '\'' +
-                ", uri='" + uri + '\'' +
-                ", iconUrl='" + iconUrl + '\'' +
+                ", uri=" + uri +
+                ", iconUrl=" + iconUrl +
                 ", active=" + active +
                 '}';
     }

--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -1,0 +1,135 @@
+package edu.harvard.iq.dataverse;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+
+/**
+ * @author Jing Ma
+ */
+// @NamedQueries({
+//    @NamedQuery( name="License.findAll",
+//                query="SELECT l FROM License l"),
+//    @NamedQuery( name="Setting.findById",
+//            query = "SELECT l FROM License l WHERE l.id=:id"),
+//    @NamedQuery( name="License.deleteById",
+//                query="DELETE FROM License l WHERE l.id=:id")
+//
+//})
+//@Entity
+public class License {
+
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//    
+//    @Column(columnDefinition="TEXT", nullable = false, unique = true)
+//    private String name;
+//    
+//    @Column(columnDefinition="TEXT")
+//    private String shortDescription;
+//    
+//    @Column(columnDefinition="TEXT", nullable = false)
+//    private String uri;
+//    
+//    @Column(columnDefinition="TEXT")
+//    private String iconUrl;
+//    
+//    @Column(nullable = false)
+//    private boolean active;
+//
+//    public License() {
+//    }
+//
+//    public License(String name, String shortDescription, String uri, String iconUrl, boolean active) {
+//        this.name = name;
+//        this.shortDescription = shortDescription;
+//        this.uri = uri;
+//        this.iconUrl = iconUrl;
+//        this.active = active;
+//    }
+//
+//    public Long getId() {
+//        return id;
+//    }
+//
+//    public void setId(Long id) {
+//        this.id = id;
+//    }
+//
+//    public String getName() {
+//        return name;
+//    }
+//
+//    public void setName(String name) {
+//        this.name = name;
+//    }
+//
+//    public String getShortDescription() {
+//        return shortDescription;
+//    }
+//
+//    public void setShortDescription(String shortDescription) {
+//        this.shortDescription = shortDescription;
+//    }
+//
+//    public String getUri() {
+//        return uri;
+//    }
+//
+//    public void setUri(String uri) {
+//        this.uri = uri;
+//    }
+//
+//    public String getIconUrl() {
+//        return iconUrl;
+//    }
+//
+//    public void setIconUrl(String iconUrl) {
+//        this.iconUrl = iconUrl;
+//    }
+//
+//    public boolean isActive() {
+//        return active;
+//    }
+//
+//    public void setActive(boolean active) {
+//        this.active = active;
+//    }
+//
+//    @Override
+//    public boolean equals(Object o) {
+//        if (this == o) return true;
+//        if (o == null || getClass() != o.getClass()) return false;
+//        License license = (License) o;
+//        return active == license.active &&
+//                Objects.equals(id, license.id) &&
+//                Objects.equals(name, license.name) &&
+//                Objects.equals(shortDescription, license.shortDescription) &&
+//                Objects.equals(uri, license.uri) &&
+//                Objects.equals(iconUrl, license.iconUrl);
+//    }
+//
+//    @Override
+//    public int hashCode() {
+//        return Objects.hash(id, name, shortDescription, uri, iconUrl, active);
+//    }
+//
+//    @Override
+//    public String toString() {
+//        return "License{" +
+//                "id=" + id +
+//                ", name='" + name + '\'' +
+//                ", shortDescription='" + shortDescription + '\'' +
+//                ", uri='" + uri + '\'' +
+//                ", iconUrl='" + iconUrl + '\'' +
+//                ", active=" + active +
+//                '}';
+//    }
+    
+}

--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -8,128 +8,134 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 /**
  * @author Jing Ma
  */
-// @NamedQueries({
-//    @NamedQuery( name="License.findAll",
-//                query="SELECT l FROM License l"),
-//    @NamedQuery( name="Setting.findById",
-//            query = "SELECT l FROM License l WHERE l.id=:id"),
-//    @NamedQuery( name="License.deleteById",
-//                query="DELETE FROM License l WHERE l.id=:id")
-//
-//})
-//@Entity
+ @NamedQueries({
+    @NamedQuery( name="License.findAll",
+                query="SELECT l FROM License l"),
+    @NamedQuery( name="License.findById",
+            query = "SELECT l FROM License l WHERE l.id=:id"),
+    @NamedQuery( name="License.deleteById",
+                query="DELETE FROM License l WHERE l.id=:id")
+
+})
+@Entity
+@Table(uniqueConstraints = {
+      @UniqueConstraint(columnNames = "name"),
+      @UniqueConstraint(columnNames = "uri")}
+)
 public class License {
 
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    private Long id;
-//    
-//    @Column(columnDefinition="TEXT", nullable = false, unique = true)
-//    private String name;
-//    
-//    @Column(columnDefinition="TEXT")
-//    private String shortDescription;
-//    
-//    @Column(columnDefinition="TEXT", nullable = false)
-//    private String uri;
-//    
-//    @Column(columnDefinition="TEXT")
-//    private String iconUrl;
-//    
-//    @Column(nullable = false)
-//    private boolean active;
-//
-//    public License() {
-//    }
-//
-//    public License(String name, String shortDescription, String uri, String iconUrl, boolean active) {
-//        this.name = name;
-//        this.shortDescription = shortDescription;
-//        this.uri = uri;
-//        this.iconUrl = iconUrl;
-//        this.active = active;
-//    }
-//
-//    public Long getId() {
-//        return id;
-//    }
-//
-//    public void setId(Long id) {
-//        this.id = id;
-//    }
-//
-//    public String getName() {
-//        return name;
-//    }
-//
-//    public void setName(String name) {
-//        this.name = name;
-//    }
-//
-//    public String getShortDescription() {
-//        return shortDescription;
-//    }
-//
-//    public void setShortDescription(String shortDescription) {
-//        this.shortDescription = shortDescription;
-//    }
-//
-//    public String getUri() {
-//        return uri;
-//    }
-//
-//    public void setUri(String uri) {
-//        this.uri = uri;
-//    }
-//
-//    public String getIconUrl() {
-//        return iconUrl;
-//    }
-//
-//    public void setIconUrl(String iconUrl) {
-//        this.iconUrl = iconUrl;
-//    }
-//
-//    public boolean isActive() {
-//        return active;
-//    }
-//
-//    public void setActive(boolean active) {
-//        this.active = active;
-//    }
-//
-//    @Override
-//    public boolean equals(Object o) {
-//        if (this == o) return true;
-//        if (o == null || getClass() != o.getClass()) return false;
-//        License license = (License) o;
-//        return active == license.active &&
-//                Objects.equals(id, license.id) &&
-//                Objects.equals(name, license.name) &&
-//                Objects.equals(shortDescription, license.shortDescription) &&
-//                Objects.equals(uri, license.uri) &&
-//                Objects.equals(iconUrl, license.iconUrl);
-//    }
-//
-//    @Override
-//    public int hashCode() {
-//        return Objects.hash(id, name, shortDescription, uri, iconUrl, active);
-//    }
-//
-//    @Override
-//    public String toString() {
-//        return "License{" +
-//                "id=" + id +
-//                ", name='" + name + '\'' +
-//                ", shortDescription='" + shortDescription + '\'' +
-//                ", uri='" + uri + '\'' +
-//                ", iconUrl='" + iconUrl + '\'' +
-//                ", active=" + active +
-//                '}';
-//    }
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition="TEXT", nullable = false)
+    private String name;
+
+    @Column(columnDefinition="TEXT")
+    private String shortDescription;
+
+    @Column(columnDefinition="TEXT", nullable = false)
+    private String uri;
+
+    @Column(columnDefinition="TEXT")
+    private String iconUrl;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    public License() {
+    }
+
+    public License(String name, String shortDescription, String uri, String iconUrl, boolean active) {
+        this.name = name;
+        this.shortDescription = shortDescription;
+        this.uri = uri;
+        this.iconUrl = iconUrl;
+        this.active = active;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getShortDescription() {
+        return shortDescription;
+    }
+
+    public void setShortDescription(String shortDescription) {
+        this.shortDescription = shortDescription;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getIconUrl() {
+        return iconUrl;
+    }
+
+    public void setIconUrl(String iconUrl) {
+        this.iconUrl = iconUrl;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        License license = (License) o;
+        return active == license.active &&
+                Objects.equals(id, license.id) &&
+                Objects.equals(name, license.name) &&
+                Objects.equals(shortDescription, license.shortDescription) &&
+                Objects.equals(uri, license.uri) &&
+                Objects.equals(iconUrl, license.iconUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, shortDescription, uri, iconUrl, active);
+    }
+
+    @Override
+    public String toString() {
+        return "License{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", shortDescription='" + shortDescription + '\'' +
+                ", uri='" + uri + '\'' +
+                ", iconUrl='" + iconUrl + '\'' +
+                ", active=" + active +
+                '}';
+    }
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -18,63 +18,63 @@ import javax.persistence.PersistenceException;
 /**
  * @author Jing Ma
  */
-//@Stateless
-//@Named
+@Stateless
+@Named
 public class LicenseServiceBean {
     
-//    @PersistenceContext
-//    EntityManager em;
-//    
-//    @EJB
-//    ActionLogServiceBean actionLogSvc;
-//    
-//    public List<License> listAll() {
-//        return em.createNamedQuery("License.findAll", License.class).getResultList();
-//    }
-//    
-//    public License get( long id ) {
-//        List<License> tokens = em.createNamedQuery("License.findById", License.class)
-//                .setParameter("id", id )
-//                .getResultList();
-//        return tokens.isEmpty() ? null : tokens.get(0);
-//    }
-//    
-//    public License save(License l) throws PersistenceException {
-//        if (l.getId() == null) {
-//            em.persist(l);
-//            return l;
-//        } else {
-//            return null;
-//        }
-//    }
-//
-//    public License set( long id, String name, String shortDescription, String uri, String iconUrl, boolean active ) {
-//        List<License> tokens = em.createNamedQuery("License.findById", License.class)
-//                .setParameter("id", Long.toString(id) )
-//                .getResultList();
-//        
-//        if(tokens.size() > 0) {
-//            License l = tokens.get(0);
-//            l.setName(name);
-//            l.setShortDescription(shortDescription);
-//            l.setUri(uri);
-//            l.setIconUrl(iconUrl);
-//            l.setActive(active);        
-//            em.merge(l);
-//            actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "set")
-//                .setInfo(name + ": " + shortDescription + ": " + uri + ": " + iconUrl + ": " + active));
-//            return l;
-//        } else {
-//            return null;
-//        }
-//    }
-//    
-//    public void delete( long id ) throws PersistenceException {
-//        actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "delete")
-//                            .setInfo(Long.toString(id)));
-//        em.createNamedQuery("License.deleteById")
-//                .setParameter("id", id)
-//                .executeUpdate();
-//    }
+    @PersistenceContext
+    EntityManager em;
+
+    @EJB
+    ActionLogServiceBean actionLogSvc;
+
+    public List<License> listAll() {
+        return em.createNamedQuery("License.findAll", License.class).getResultList();
+    }
+
+    public License get( long id ) {
+        List<License> tokens = em.createNamedQuery("License.findById", License.class)
+                .setParameter("id", id )
+                .getResultList();
+        return tokens.isEmpty() ? null : tokens.get(0);
+    }
+
+    public License save(License l) throws PersistenceException {
+        if (l.getId() == null) {
+            em.persist(l);
+            return l;
+        } else {
+            return null;
+        }
+    }
+
+    public License set( long id, String name, String shortDescription, String uri, String iconUrl, boolean active ) {
+        List<License> tokens = em.createNamedQuery("License.findById", License.class)
+                .setParameter("id", id )
+                .getResultList();
+
+        if(tokens.size() > 0) {
+            License l = tokens.get(0);
+            l.setName(name);
+            l.setShortDescription(shortDescription);
+            l.setUri(uri);
+            l.setIconUrl(iconUrl);
+            l.setActive(active);        
+            em.merge(l);
+            actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "set")
+                .setInfo(name + ": " + shortDescription + ": " + uri + ": " + iconUrl + ": " + active));
+            return l;
+        } else {
+            return null;
+        }
+    }
+
+    public int delete( long id ) throws PersistenceException {
+        actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "delete")
+                            .setInfo(Long.toString(id)));
+        return em.createNamedQuery("License.deleteById")
+                .setParameter("id", id)
+                .executeUpdate();
+    }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -33,23 +33,23 @@ public class LicenseServiceBean {
     }
 
     public License getById(long id) throws FetchException {
-        List<License> tokens = em.createNamedQuery("License.findById", License.class)
+        List<License> licenses = em.createNamedQuery("License.findById", License.class)
                 .setParameter("id", id )
                 .getResultList();
-        if (tokens.isEmpty()) {
+        if (licenses.isEmpty()) {
             throw new FetchException("License with that ID doesn't exist.");
         }
-        return tokens.get(0);
+        return licenses.get(0);
     }
 
     public License getByName(String name) throws FetchException {
-        List<License> tokens = em.createNamedQuery("License.findByName", License.class)
+        List<License> licenses = em.createNamedQuery("License.findByName", License.class)
                 .setParameter("name", name )
                 .getResultList();
-        if (tokens.isEmpty()) {
+        if (licenses.isEmpty()) {
             throw new FetchException("License with that name doesn't exist.");
         }
-        return tokens.get(0);
+        return licenses.get(0);
     }
 
     public License save(License license) throws PersistenceException, RequestBodyException {
@@ -62,12 +62,12 @@ public class LicenseServiceBean {
     }
 
     public void setById(long id, String name, String shortDescription, URI uri, URI iconUrl, boolean active) throws UpdateException {
-        List<License> tokens = em.createNamedQuery("License.findById", License.class)
+        List<License> licenses = em.createNamedQuery("License.findById", License.class)
                 .setParameter("id", id )
                 .getResultList();
 
-        if(tokens.size() > 0) {
-            License license = tokens.get(0);
+        if(licenses.size() > 0) {
+            License license = licenses.get(0);
             license.setName(name);
             license.setShortDescription(shortDescription);
             license.setUri(uri);
@@ -82,12 +82,12 @@ public class LicenseServiceBean {
     }
 
     public void setByName(String name, String shortDescription, URI uri, URI iconUrl, boolean active) throws UpdateException {
-        List<License> tokens = em.createNamedQuery("License.findByName", License.class)
+        List<License> licenses = em.createNamedQuery("License.findByName", License.class)
                 .setParameter("name", name )
                 .getResultList();
 
-        if(tokens.size() > 0) {
-            License license = tokens.get(0);
+        if(licenses.size() > 0) {
+            License license = licenses.get(0);
             license.setShortDescription(shortDescription);
             license.setUri(uri);
             license.setIconUrl(iconUrl);

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -1,0 +1,80 @@
+package edu.harvard.iq.dataverse;
+
+import edu.harvard.iq.dataverse.actionlogging.ActionLogRecord;
+import edu.harvard.iq.dataverse.actionlogging.ActionLogServiceBean;
+import edu.harvard.iq.dataverse.authorization.DataverseRole;
+import edu.harvard.iq.dataverse.search.IndexResponse;
+import edu.harvard.iq.dataverse.settings.Setting;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.inject.Named;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceException;
+
+/**
+ * @author Jing Ma
+ */
+//@Stateless
+//@Named
+public class LicenseServiceBean {
+    
+//    @PersistenceContext
+//    EntityManager em;
+//    
+//    @EJB
+//    ActionLogServiceBean actionLogSvc;
+//    
+//    public List<License> listAll() {
+//        return em.createNamedQuery("License.findAll", License.class).getResultList();
+//    }
+//    
+//    public License get( long id ) {
+//        List<License> tokens = em.createNamedQuery("License.findById", License.class)
+//                .setParameter("id", id )
+//                .getResultList();
+//        return tokens.isEmpty() ? null : tokens.get(0);
+//    }
+//    
+//    public License save(License l) throws PersistenceException {
+//        if (l.getId() == null) {
+//            em.persist(l);
+//            return l;
+//        } else {
+//            return null;
+//        }
+//    }
+//
+//    public License set( long id, String name, String shortDescription, String uri, String iconUrl, boolean active ) {
+//        List<License> tokens = em.createNamedQuery("License.findById", License.class)
+//                .setParameter("id", Long.toString(id) )
+//                .getResultList();
+//        
+//        if(tokens.size() > 0) {
+//            License l = tokens.get(0);
+//            l.setName(name);
+//            l.setShortDescription(shortDescription);
+//            l.setUri(uri);
+//            l.setIconUrl(iconUrl);
+//            l.setActive(active);        
+//            em.merge(l);
+//            actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "set")
+//                .setInfo(name + ": " + shortDescription + ": " + uri + ": " + iconUrl + ": " + active));
+//            return l;
+//        } else {
+//            return null;
+//        }
+//    }
+//    
+//    public void delete( long id ) throws PersistenceException {
+//        actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "delete")
+//                            .setInfo(Long.toString(id)));
+//        em.createNamedQuery("License.deleteById")
+//                .setParameter("id", id)
+//                .executeUpdate();
+//    }
+
+}

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -61,7 +61,7 @@ public class LicenseServiceBean {
         }
     }
 
-    public License setById(long id, String name, String shortDescription, URI uri, URL iconUrl, boolean active) throws UpdateException {
+    public void setById(long id, String name, String shortDescription, URI uri, URI iconUrl, boolean active) throws UpdateException {
         List<License> tokens = em.createNamedQuery("License.findById", License.class)
                 .setParameter("id", id )
                 .getResultList();
@@ -76,13 +76,12 @@ public class LicenseServiceBean {
             em.merge(license);
             actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "set")
                 .setInfo(name + ": " + shortDescription + ": " + uri + ": " + iconUrl + ": " + active));
-            return license;
         } else {
             throw new UpdateException("There is no existing License with that ID. To add a license use POST.");
         }
     }
 
-    public License setByName(String name, String shortDescription, URI uri, URL iconUrl, boolean active) throws UpdateException {
+    public void setByName(String name, String shortDescription, URI uri, URI iconUrl, boolean active) throws UpdateException {
         List<License> tokens = em.createNamedQuery("License.findByName", License.class)
                 .setParameter("name", name )
                 .getResultList();
@@ -96,7 +95,6 @@ public class LicenseServiceBean {
             em.merge(license);
             actionLogSvc.log( new ActionLogRecord(ActionLogRecord.ActionType.Admin, "set")
                 .setInfo(name + ": " + shortDescription + ": " + uri + ": " + iconUrl + ": " + active));
-            return license;
         } else {
             throw new UpdateException("There is no existing License with that name. To add a license use POST.");
         }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1926,54 +1926,56 @@ public class Admin extends AbstractApiBean {
 
     }
     
-//    @GET
-//    @Path("/licenses")
-//    public Response getLicenses() {
-//        return ok(licenseService.listAll().stream()
-//        		.map(JsonPrinter::json)
-//        		.collect(toJsonArray()));
-//    }
-//    
-//    @GET
-//    @Path("/licenses/{id}")
-//    public Response getLicense(@PathParam("id") long id) {
-//    	License l = licenseService.get(id);
-//    	if (l == null) {
-//    		return error(Response.Status.NOT_FOUND, "Not Found.");
-//		}
-//		return ok(json(l));
-//    }
-//    
-//    @POST
-//    @Path("/licenses")
-//    public Response addLicense(License l) {
-//		try {
-//			licenseService.save(l);
-//			return created("/api/admin/licenses", Json.createObjectBuilder().add("message", "License created"));
-//		} catch(PersistenceException e) {
-//			return error(Response.Status.CONFLICT, "A license with the same URI or name is already present.");
-//		}
-//    }
-//
-//	@PUT
-//	@Path("/licenses/{id}")
-//	public Response putLicense(@PathParam("id") long id, License l) {
-//		License updated = licenseService.set(id, l.getName(), l.getShortDescription(), l.getUri(), l.getIconUrl(), l.isActive());
-//		if (updated == null) {
-//			return error(Response.Status.BAD_REQUEST, "Bad Request. There is no existing LicenseInfo with that ID. To add a license use POST.");
-//		}
-//		return ok("License with ID " + id + " was replaced.");
-//	}
-//
-//	@DELETE
-//	@Path("/licenses/{id}")
-//	public Response deleteLicense(@PathParam("id") long id) {
-//		try {
-//			licenseService.delete(id);
-//			return ok("OK. License with ID " + id + " was deleted.");
-//		} catch (PersistenceException e) {
-//			return error(Response.Status.BAD_REQUEST, "The license is still in used and cannot be deleted.");
-//		}
-//	}
+    @GET
+    @Path("/licenses")
+    public Response getLicenses() {
+        return ok(licenseService.listAll().stream()
+        		.map(JsonPrinter::json)
+        		.collect(toJsonArray()));
+    }
+
+    @GET
+    @Path("/licenses/{id}")
+    public Response getLicense(@PathParam("id") long id) {
+    	License l = licenseService.get(id);
+    	if (l == null) {
+    		return error(Response.Status.NOT_FOUND, "Not Found.");
+		}
+		return ok(json(l));
+    }
+
+    @POST
+    @Path("/licenses")
+    public Response addLicense(License l) {
+		try {
+			License added = licenseService.save(l);
+			if (added == null) {
+				return error(Response.Status.BAD_REQUEST, "Bad Request.");
+			}
+			return created("/api/admin/licenses", Json.createObjectBuilder().add("message", "License created"));
+		} catch(PersistenceException e) {
+			return error(Response.Status.CONFLICT, "A license with the same URI or name is already present.");
+		}
+    }
+
+	@PUT
+	@Path("/licenses/{id}")
+	public Response putLicense(@PathParam("id") long id, License l) {
+		License updated = licenseService.set(id, l.getName(), l.getShortDescription(), l.getUri(), l.getIconUrl(), l.isActive());
+		if (updated == null) {
+			return error(Response.Status.BAD_REQUEST, "Bad Request. There is no existing LicenseInfo with that ID. To add a license use POST.");
+		}
+		return ok("License with ID " + id + " was replaced.");
+	}
+
+	@DELETE
+	@Path("/licenses/{id}")
+	public Response deleteLicense(@PathParam("id") long id) {
+		int result = licenseService.delete(id);
+		if (result == 1) {
+			return ok("OK. License with ID " + id + " was deleted.");
+		}
+		return error(Response.Status.NOT_FOUND, "A license with ID " + id + " doesn't exist.");
+	}
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1930,52 +1930,52 @@ public class Admin extends AbstractApiBean {
     @Path("/licenses")
     public Response getLicenses() {
         return ok(licenseService.listAll().stream()
-        		.map(JsonPrinter::json)
-        		.collect(toJsonArray()));
+                .map(JsonPrinter::json)
+                .collect(toJsonArray()));
     }
 
     @GET
     @Path("/licenses/{id}")
     public Response getLicense(@PathParam("id") long id) {
-    	License l = licenseService.get(id);
-    	if (l == null) {
-    		return error(Response.Status.NOT_FOUND, "Not Found.");
-		}
-		return ok(json(l));
+        License l = licenseService.get(id);
+        if (l == null) {
+            return error(Response.Status.NOT_FOUND, "Not Found.");
+        }
+        return ok(json(l));
     }
 
     @POST
     @Path("/licenses")
     public Response addLicense(License l) {
-		try {
-			License added = licenseService.save(l);
-			if (added == null) {
-				return error(Response.Status.BAD_REQUEST, "Bad Request.");
-			}
-			return created("/api/admin/licenses", Json.createObjectBuilder().add("message", "License created"));
-		} catch(PersistenceException e) {
-			return error(Response.Status.CONFLICT, "A license with the same URI or name is already present.");
-		}
+        try {
+            License added = licenseService.save(l);
+            if (added == null) {
+                return error(Response.Status.BAD_REQUEST, "Bad Request.");
+            }
+            return created("/api/admin/licenses", Json.createObjectBuilder().add("message", "License created"));
+        } catch(PersistenceException e) {
+            return error(Response.Status.CONFLICT, "A license with the same URI or name is already present.");
+        }
     }
 
-	@PUT
-	@Path("/licenses/{id}")
-	public Response putLicense(@PathParam("id") long id, License l) {
-		License updated = licenseService.set(id, l.getName(), l.getShortDescription(), l.getUri(), l.getIconUrl(), l.isActive());
-		if (updated == null) {
-			return error(Response.Status.BAD_REQUEST, "Bad Request. There is no existing LicenseInfo with that ID. To add a license use POST.");
-		}
-		return ok("License with ID " + id + " was replaced.");
-	}
+    @PUT
+    @Path("/licenses/{id}")
+    public Response putLicense(@PathParam("id") long id, License l) {
+        License updated = licenseService.set(id, l.getName(), l.getShortDescription(), l.getUri(), l.getIconUrl(), l.isActive());
+        if (updated == null) {
+            return error(Response.Status.BAD_REQUEST, "Bad Request. There is no existing LicenseInfo with that ID. To add a license use POST.");
+        }
+        return ok("License with ID " + id + " was replaced.");
+    }
 
-	@DELETE
-	@Path("/licenses/{id}")
-	public Response deleteLicense(@PathParam("id") long id) {
-		int result = licenseService.delete(id);
-		if (result == 1) {
-			return ok("OK. License with ID " + id + " was deleted.");
-		}
-		return error(Response.Status.NOT_FOUND, "A license with ID " + id + " doesn't exist.");
-	}
+    @DELETE
+    @Path("/licenses/{id}")
+    public Response deleteLicense(@PathParam("id") long id) {
+        int result = licenseService.delete(id);
+        if (result == 1) {
+            return ok("OK. License with ID " + id + " was deleted.");
+        }
+        return error(Response.Status.NOT_FOUND, "A license with ID " + id + " doesn't exist.");
+    }
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -44,7 +44,6 @@ import edu.harvard.iq.dataverse.engine.command.impl.AbstractSubmitToArchiveComma
 import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
 import edu.harvard.iq.dataverse.settings.Setting;
 import edu.harvard.iq.dataverse.util.json.JsonPrinter;
-import java.net.URISyntaxException;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
@@ -1927,11 +1926,7 @@ public class Admin extends AbstractApiBean {
     public Response getLicenses() {
     	JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
 		for(License license : licenseService.listAll()) {
-			try {
-				arrayBuilder.add(JsonPrinter.json(license));
-			} catch (URISyntaxException e) {
-				return error(Status.INTERNAL_SERVER_ERROR, "Incorrect URI in JSON");
-			}
+			arrayBuilder.add(JsonPrinter.json(license));
 		}
         return ok(arrayBuilder);
     }
@@ -1944,8 +1939,6 @@ public class Admin extends AbstractApiBean {
         	return ok(json(license));
 		} catch (FetchException e) {
 			return error(Response.Status.NOT_FOUND, e.getMessage());
-		} catch (URISyntaxException e) {
-			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
 	}
 
@@ -1957,8 +1950,6 @@ public class Admin extends AbstractApiBean {
         	return ok(json(license));
 		} catch (FetchException e) {
 			return error(Response.Status.NOT_FOUND, e.getMessage());
-		} catch (URISyntaxException e) {
-			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
 	}
 
@@ -1982,8 +1973,6 @@ public class Admin extends AbstractApiBean {
 			licenseService.setById(id, license.getName(), license.getShortDescription(), license.getUri(), license.getIconUrl(), license.isActive());
 		} catch (UpdateException e) {
 			return error(Response.Status.BAD_REQUEST, e.getMessage());
-		} catch (URISyntaxException e) {
-			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
 		return ok("License with ID " + id + " was replaced.");
     }
@@ -1995,8 +1984,6 @@ public class Admin extends AbstractApiBean {
 			licenseService.setByName(license.getName(), license.getShortDescription(), license.getUri(), license.getIconUrl(), license.isActive());
 		} catch (UpdateException e) {
 			return error(Response.Status.BAD_REQUEST, e.getMessage());
-		} catch (URISyntaxException e) {
-			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
 		return ok("License with name " + name + " was replaced.");
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -44,6 +44,7 @@ import edu.harvard.iq.dataverse.engine.command.impl.AbstractSubmitToArchiveComma
 import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
 import edu.harvard.iq.dataverse.settings.Setting;
 import edu.harvard.iq.dataverse.util.json.JsonPrinter;
+import java.net.URISyntaxException;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
@@ -1924,9 +1925,15 @@ public class Admin extends AbstractApiBean {
     @GET
     @Path("/licenses")
     public Response getLicenses() {
-        return ok(licenseService.listAll().stream()
-                .map(JsonPrinter::json)
-                .collect(toJsonArray()));
+    	JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+		for(License license : licenseService.listAll()) {
+			try {
+				arrayBuilder.add(JsonPrinter.json(license));
+			} catch (URISyntaxException e) {
+				return error(Status.INTERNAL_SERVER_ERROR, "Incorrect URI in JSON");
+			}
+		}
+        return ok(arrayBuilder);
     }
 
     @GET
@@ -1937,8 +1944,10 @@ public class Admin extends AbstractApiBean {
         	return ok(json(license));
 		} catch (FetchException e) {
 			return error(Response.Status.NOT_FOUND, e.getMessage());
+		} catch (URISyntaxException e) {
+			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
-    }
+	}
 
     @GET
     @Path("/licenses/name/{name}")
@@ -1948,8 +1957,10 @@ public class Admin extends AbstractApiBean {
         	return ok(json(license));
 		} catch (FetchException e) {
 			return error(Response.Status.NOT_FOUND, e.getMessage());
+		} catch (URISyntaxException e) {
+			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
-    }
+	}
 
     @POST
     @Path("/licenses")
@@ -1971,8 +1982,10 @@ public class Admin extends AbstractApiBean {
 			licenseService.setById(id, license.getName(), license.getShortDescription(), license.getUri(), license.getIconUrl(), license.isActive());
 		} catch (UpdateException e) {
 			return error(Response.Status.BAD_REQUEST, e.getMessage());
+		} catch (URISyntaxException e) {
+			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
-        return ok("License with ID " + id + " was replaced.");
+		return ok("License with ID " + id + " was replaced.");
     }
 
     @PUT
@@ -1982,8 +1995,10 @@ public class Admin extends AbstractApiBean {
 			licenseService.setByName(license.getName(), license.getShortDescription(), license.getUri(), license.getIconUrl(), license.isActive());
 		} catch (UpdateException e) {
 			return error(Response.Status.BAD_REQUEST, e.getMessage());
+		} catch (URISyntaxException e) {
+			return error(Response.Status.BAD_REQUEST, "Incorrect URI in JSON");
 		}
-        return ok("License with name " + name + " was replaced.");
+		return ok("License with name " + name + " was replaced.");
     }
 
     @DELETE

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -16,6 +16,8 @@ import edu.harvard.iq.dataverse.DvObject;
 import edu.harvard.iq.dataverse.EMailValidator;
 import edu.harvard.iq.dataverse.EjbDataverseEngine;
 import edu.harvard.iq.dataverse.GlobalId;
+import edu.harvard.iq.dataverse.License;
+import edu.harvard.iq.dataverse.LicenseServiceBean;
 import edu.harvard.iq.dataverse.RoleAssignment;
 import edu.harvard.iq.dataverse.UserServiceBean;
 import edu.harvard.iq.dataverse.actionlogging.ActionLogRecord;
@@ -42,9 +44,11 @@ import edu.harvard.iq.dataverse.dataaccess.StorageIO;
 import edu.harvard.iq.dataverse.engine.command.impl.AbstractSubmitToArchiveCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
 import edu.harvard.iq.dataverse.settings.Setting;
+import edu.harvard.iq.dataverse.util.json.JsonPrinter;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
+import javax.persistence.PersistenceException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -152,6 +156,8 @@ public class Admin extends AbstractApiBean {
         ExplicitGroupServiceBean explicitGroupService;
         @EJB
         BannerMessageServiceBean bannerMessageService;
+        @EJB
+		LicenseServiceBean licenseService;
         
 
 	// Make the session available
@@ -1919,5 +1925,55 @@ public class Admin extends AbstractApiBean {
                 .collect(toJsonArray()));
 
     }
+    
+//    @GET
+//    @Path("/licenses")
+//    public Response getLicenses() {
+//        return ok(licenseService.listAll().stream()
+//        		.map(JsonPrinter::json)
+//        		.collect(toJsonArray()));
+//    }
+//    
+//    @GET
+//    @Path("/licenses/{id}")
+//    public Response getLicense(@PathParam("id") long id) {
+//    	License l = licenseService.get(id);
+//    	if (l == null) {
+//    		return error(Response.Status.NOT_FOUND, "Not Found.");
+//		}
+//		return ok(json(l));
+//    }
+//    
+//    @POST
+//    @Path("/licenses")
+//    public Response addLicense(License l) {
+//		try {
+//			licenseService.save(l);
+//			return created("/api/admin/licenses", Json.createObjectBuilder().add("message", "License created"));
+//		} catch(PersistenceException e) {
+//			return error(Response.Status.CONFLICT, "A license with the same URI or name is already present.");
+//		}
+//    }
+//
+//	@PUT
+//	@Path("/licenses/{id}")
+//	public Response putLicense(@PathParam("id") long id, License l) {
+//		License updated = licenseService.set(id, l.getName(), l.getShortDescription(), l.getUri(), l.getIconUrl(), l.isActive());
+//		if (updated == null) {
+//			return error(Response.Status.BAD_REQUEST, "Bad Request. There is no existing LicenseInfo with that ID. To add a license use POST.");
+//		}
+//		return ok("License with ID " + id + " was replaced.");
+//	}
+//
+//	@DELETE
+//	@Path("/licenses/{id}")
+//	public Response deleteLicense(@PathParam("id") long id) {
+//		try {
+//			licenseService.delete(id);
+//			return ok("OK. License with ID " + id + " was deleted.");
+//		} catch (PersistenceException e) {
+//			return error(Response.Status.BAD_REQUEST, "The license is still in used and cannot be deleted.");
+//		}
+//	}
     
 }

--- a/src/main/java/edu/harvard/iq/dataverse/api/FetchException.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/FetchException.java
@@ -1,0 +1,17 @@
+package edu.harvard.iq.dataverse.api;
+
+/**
+ *
+ * @author Jing Ma
+ */
+public class FetchException extends Exception {
+
+    public FetchException(String message) {
+        super(message);
+    }
+
+    public FetchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/harvard/iq/dataverse/api/RequestBodyException.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/RequestBodyException.java
@@ -1,0 +1,17 @@
+package edu.harvard.iq.dataverse.api;
+
+/**
+ *
+ * @author Jing Ma
+ */
+public class RequestBodyException extends Exception {
+
+    public RequestBodyException(String message) {
+        super(message);
+    }
+
+    public RequestBodyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/harvard/iq/dataverse/api/UpdateException.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/UpdateException.java
@@ -1,0 +1,17 @@
+package edu.harvard.iq.dataverse.api;
+
+/**
+ *
+ * @author Jing Ma
+ */
+public class UpdateException extends Exception {
+
+    public UpdateException(String message) {
+        super(message);
+    }
+
+    public UpdateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -45,6 +45,7 @@ import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectB
 import edu.harvard.iq.dataverse.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepData;
 
+import java.net.URISyntaxException;
 import java.util.*;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -777,14 +778,14 @@ public class JsonPrinter {
                     .add("name", aFacet.getDatasetFieldType().getDisplayName());
     }
 
-    public static JsonObjectBuilder json(License l) {
+    public static JsonObjectBuilder json(License license) throws URISyntaxException {
         return jsonObjectBuilder()
-            .add("id", l.getId())
-            .add("name", l.getName())
-            .add("shortDescription", l.getShortDescription())
-            .add("uri", l.getUri().toString())
-            .add("iconUrl", l.getIconUrl().toString())
-            .add("active", l.isActive());
+            .add("id", license.getId())
+            .add("name", license.getName())
+            .add("shortDescription", license.getShortDescription())
+            .add("uri", license.getUri().toString())
+            .add("iconUrl", license.getIconUrl().toString())
+            .add("active", license.isActive());
     }
         
     public static Collector<String, JsonArrayBuilder, JsonArrayBuilder> stringsToJsonArray() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -778,7 +778,7 @@ public class JsonPrinter {
                     .add("name", aFacet.getDatasetFieldType().getDisplayName());
     }
 
-    public static JsonObjectBuilder json(License license) throws URISyntaxException {
+    public static JsonObjectBuilder json(License license) {
         return jsonObjectBuilder()
             .add("id", license.getId())
             .add("name", license.getName())

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -777,15 +777,15 @@ public class JsonPrinter {
                     .add("name", aFacet.getDatasetFieldType().getDisplayName());
     }
 
-//    public static JsonObjectBuilder json(License l) {
-//        return jsonObjectBuilder()
-//            .add("id", l.getId())
-//            .add("name", l.getName())
-//            .add("shortDescription", l.getShortDescription())
-//            .add("uri", l.getUri())
-//            .add("iconUrl", l.getIconUrl())
-//            .add("active", l.isActive());
-//    }
+    public static JsonObjectBuilder json(License l) {
+        return jsonObjectBuilder()
+            .add("id", l.getId())
+            .add("name", l.getName())
+            .add("shortDescription", l.getShortDescription())
+            .add("uri", l.getUri())
+            .add("iconUrl", l.getIconUrl())
+            .add("active", l.isActive());
+    }
         
     public static Collector<String, JsonArrayBuilder, JsonArrayBuilder> stringsToJsonArray() {
         return new Collector<String, JsonArrayBuilder, JsonArrayBuilder>() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -16,6 +16,7 @@ import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.DataverseContact;
 import edu.harvard.iq.dataverse.DataverseFacet;
 import edu.harvard.iq.dataverse.DataverseTheme;
+import edu.harvard.iq.dataverse.License;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import edu.harvard.iq.dataverse.authorization.groups.impl.maildomain.MailDomainGroup;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUser;
@@ -775,6 +776,16 @@ public class JsonPrinter {
                     .add("id", String.valueOf(aFacet.getId())) // TODO should just be id I think
                     .add("name", aFacet.getDatasetFieldType().getDisplayName());
     }
+
+//    public static JsonObjectBuilder json(License l) {
+//        return jsonObjectBuilder()
+//            .add("id", l.getId())
+//            .add("name", l.getName())
+//            .add("shortDescription", l.getShortDescription())
+//            .add("uri", l.getUri())
+//            .add("iconUrl", l.getIconUrl())
+//            .add("active", l.isActive());
+//    }
         
     public static Collector<String, JsonArrayBuilder, JsonArrayBuilder> stringsToJsonArray() {
         return new Collector<String, JsonArrayBuilder, JsonArrayBuilder>() {

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -782,8 +782,8 @@ public class JsonPrinter {
             .add("id", l.getId())
             .add("name", l.getName())
             .add("shortDescription", l.getShortDescription())
-            .add("uri", l.getUri())
-            .add("iconUrl", l.getIconUrl())
+            .add("uri", l.getUri().toString())
+            .add("iconUrl", l.getIconUrl().toString())
             .add("active", l.isActive());
     }
         

--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -809,38 +809,57 @@ public class AdminIT {
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
         
-        Response getLicenseResponse = UtilIT.getLicense(1L);
-        getLicenseResponse.prettyPrint();
-        body = getLicenseResponse.getBody().asString();
+        Response getLicenseByIdResponse = UtilIT.getLicenseById(1L);
+        getLicenseByIdResponse.prettyPrint();
+        body = getLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
         
-        Response getLicenseErrorResponse = UtilIT.getLicense(10L);
+        Response getLicenseByNameResponse = UtilIT.getLicenseByName("");
+        getLicenseByNameResponse.prettyPrint();
+        body = getLicenseByNameResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response getLicenseErrorResponse = UtilIT.getLicenseById(10L);
         getLicenseErrorResponse.prettyPrint();
         body = getLicenseErrorResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("ERROR", status);
         
         pathToJsonFile = "scripts/api/data/licenseUpdate.json";
-        Response updateLicenseResponse = UtilIT.updateLicense(pathToJsonFile, 1L);
-        updateLicenseResponse.prettyPrint();
-        body = updateLicenseResponse.getBody().asString();
+        Response updateLicenseByIdResponse = UtilIT.updateLicenseById(pathToJsonFile, 1L);
+        updateLicenseByIdResponse.prettyPrint();
+        body = updateLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
         
-        Response updateLicenseErrorResponse = UtilIT.updateLicense(pathToJsonFile, 10L);
+        pathToJsonFile = "scripts/api/data/licenseUpdate.json";
+        Response updateLicenseByNameResponse = UtilIT.updateLicenseByName(pathToJsonFile, "");
+        updateLicenseByNameResponse.prettyPrint();
+        body = updateLicenseByNameResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response updateLicenseErrorResponse = UtilIT.updateLicenseById(pathToJsonFile, 10L);
         updateLicenseErrorResponse.prettyPrint();
         body = updateLicenseErrorResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("ERROR", status);
         
-        Response deleteLicenseResponse = UtilIT.deleteLicense(1L);
-        deleteLicenseResponse.prettyPrint();
-        body = deleteLicenseResponse.getBody().asString();
+        Response deleteLicenseByIdResponse = UtilIT.deleteLicenseById(1L);
+        deleteLicenseByIdResponse.prettyPrint();
+        body = deleteLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
         
-        Response deleteLicenseErrorResponse = UtilIT.deleteLicense(10L);
+        Response deleteLicenseByNameResponse = UtilIT.deleteLicenseByName("");
+        deleteLicenseByNameResponse.prettyPrint();
+        body = deleteLicenseByNameResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response deleteLicenseErrorResponse = UtilIT.deleteLicenseById(10L);
         deleteLicenseErrorResponse.prettyPrint();
         body = deleteLicenseErrorResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");

--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -785,4 +785,66 @@ public class AdminIT {
         assertEquals("OK", status);
         
     }
+    
+    @Test
+    public void testLicenses(){
+        
+        String pathToJsonFile = "scripts/api/data/license.json";
+        Response addLicenseResponse = UtilIT.addLicense(pathToJsonFile);
+        addLicenseResponse.prettyPrint();
+        String body = addLicenseResponse.getBody().asString();
+        String status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        pathToJsonFile = "scripts/api/data/licenseError.json";
+        Response addLicenseErrorResponse = UtilIT.addLicense(pathToJsonFile);
+        addLicenseErrorResponse.prettyPrint();
+        body = addLicenseErrorResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("ERROR", status);
+        
+        Response getLicensesResponse = UtilIT.getLicenses();
+        getLicensesResponse.prettyPrint();
+        body = getLicensesResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response getLicenseResponse = UtilIT.getLicense(1L);
+        getLicenseResponse.prettyPrint();
+        body = getLicenseResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response getLicenseErrorResponse = UtilIT.getLicense(10L);
+        getLicenseErrorResponse.prettyPrint();
+        body = getLicenseErrorResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("ERROR", status);
+        
+        pathToJsonFile = "scripts/api/data/licenseUpdate.json";
+        Response updateLicenseResponse = UtilIT.updateLicense(pathToJsonFile, 1L);
+        updateLicenseResponse.prettyPrint();
+        body = updateLicenseResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response updateLicenseErrorResponse = UtilIT.updateLicense(pathToJsonFile, 10L);
+        updateLicenseErrorResponse.prettyPrint();
+        body = updateLicenseErrorResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("ERROR", status);
+        
+        Response deleteLicenseResponse = UtilIT.deleteLicense(1L);
+        deleteLicenseResponse.prettyPrint();
+        body = deleteLicenseResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("OK", status);
+        
+        Response deleteLicenseErrorResponse = UtilIT.deleteLicense(10L);
+        deleteLicenseErrorResponse.prettyPrint();
+        body = deleteLicenseErrorResponse.getBody().asString();
+        status = JsonPath.from(body).getString("status");
+        assertEquals("ERROR", status);
+        
+    }
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2523,5 +2523,46 @@ public class UtilIT {
         return "0";
     }
     
+    static Response addLicense(String pathToJsonFile) {
+        String jsonIn = getDatasetJson(pathToJsonFile);
+        
+        Response addLicenseResponse = given()               
+                .body(jsonIn)
+                .contentType("application/json")
+                .post("/api/admin/licenses");
+        return addLicenseResponse;
+    }
+    
+    static Response getLicenses() {
+        
+        Response getLicensesResponse = given()               
+                .get("/api/admin/licenses");
+        return getLicensesResponse;
+    }
+    
+    static Response getLicense(Long id) {
+        
+        Response getLicenseResponse = given()               
+                .get("/api/admin/licenses/"+id.toString());
+        return getLicenseResponse;
+    }
+    
+    static Response updateLicense(String pathToJsonFile, Long id) {
+        String jsonIn = getDatasetJson(pathToJsonFile);
+        
+        Response updateLicenseResponse = given()               
+                .body(jsonIn)
+                .contentType("application/json")
+                .put("/api/admin/licenses/"+id.toString());
+        return updateLicenseResponse;
+    }
+    
+    static Response deleteLicense(Long id) {
+        
+        Response deleteLicenseResponse = given()               
+                .delete("/api/admin/licenses/"+id.toString());
+        return deleteLicenseResponse;
+    }
+    
     
 }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2540,27 +2540,51 @@ public class UtilIT {
         return getLicensesResponse;
     }
     
-    static Response getLicense(Long id) {
+    static Response getLicenseById(Long id) {
         
         Response getLicenseResponse = given()               
-                .get("/api/admin/licenses/"+id.toString());
+                .get("/api/admin/licenses/id/"+id.toString());
         return getLicenseResponse;
     }
     
-    static Response updateLicense(String pathToJsonFile, Long id) {
+    static Response getLicenseByName(String name) {
+        
+        Response getLicenseResponse = given()               
+                .get("/api/admin/licenses/name/"+name);
+        return getLicenseResponse;
+    }
+    
+    static Response updateLicenseById(String pathToJsonFile, Long id) {
         String jsonIn = getDatasetJson(pathToJsonFile);
         
         Response updateLicenseResponse = given()               
                 .body(jsonIn)
                 .contentType("application/json")
-                .put("/api/admin/licenses/"+id.toString());
+                .put("/api/admin/licenses/id/"+id.toString());
         return updateLicenseResponse;
     }
     
-    static Response deleteLicense(Long id) {
+    static Response updateLicenseByName(String pathToJsonFile, String name) {
+        String jsonIn = getDatasetJson(pathToJsonFile);
+        
+        Response updateLicenseResponse = given()               
+                .body(jsonIn)
+                .contentType("application/json")
+                .put("/api/admin/licenses/name/"+name);
+        return updateLicenseResponse;
+    }
+    
+    static Response deleteLicenseById(Long id) {
         
         Response deleteLicenseResponse = given()               
-                .delete("/api/admin/licenses/"+id.toString());
+                .delete("/api/admin/licenses/id/"+id.toString());
+        return deleteLicenseResponse;
+    }
+    
+    static Response deleteLicenseByName(String name) {
+        
+        Response deleteLicenseResponse = given()               
+                .delete("/api/admin/licenses/name/"+name);
         return deleteLicenseResponse;
     }
     


### PR DESCRIPTION
**What this PR does / why we need it**: Adds DB table, API and business logic for multiple licenses.

**Which issue(s) this PR closes**: -

Closes #-

**Special notes for your reviewer**: -

**Suggestions on how to test this**: Use postman or curl to GET, POST, PUT and DELETE. Here's an example json you can post:
```
{
    "name": "Apache License",
    "shortDescription": "License description",
    "uri": "www.apache.com",
    "iconUrl": "www.icon.com",
    "active": false
}
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**: -

**Is there a release notes update needed for this change?**: -

**Additional documentation**: -
