### PR TITLE
Added the cvoc-interface.js file to the application resources

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -5464,7 +5464,7 @@ public class DatasetPage implements Serializable {
                 if (jo.containsKey("map-query"))
                     cvocMapQuery = jo.getString("map-query");
                 logger.fine("cvoc - map-query: " + cvocMapQuery);
-                String cvocJsUrl = "http://localhost/interface.js";
+                String cvocJsUrl = "/resources/js/cvoc-interface.js";
                 if (jo.containsKey("js-url"))
                     cvocJsUrl = jo.getString("js-url");
                 logger.fine("cvoc - js-url: " + cvocJsUrl);

--- a/src/main/webapp/resources/js/cvoc-interface.js
+++ b/src/main/webapp/resources/js/cvoc-interface.js
@@ -1,0 +1,55 @@
+// depends on jQuery ajax
+var mapquery = 'prefLabel';
+var mapid = 'uri';
+var mapping = { query: mapquery,  id: mapid };
+
+// autocomplete calls this
+function autointerface(request, response, cv, mapping) {
+    var protocol = cv.protocol;
+    if (!protocol) { protocol = 'skosmos'; };//default
+    if (protocol == 'skosmos') {
+        return(skosmos(request, response, cv, mapping)); }
+    if (protocol == 'example') {
+        return(autoexample(request, response)); };
+};
+
+function skosmos(request, response, cv, mapping) {
+    var termParentUri = "";
+    if (cv.termParentUri != "")
+        termParentUri = "&parent=" + cv.termParentUri;
+    var result = [];
+    var tmp = $.ajax({
+        url:  cv.cvocUrl + '/rest/v1/search?unique=true&vocab=' + cv.selectedVocab + termParentUri,
+        dataType: "json",
+        data: { query: request.term + '*' },
+        success: function(data) {
+            var results = data.results;
+            var queries = [];
+            var array = [];
+            $.each(results, function(i, item) {
+                queries.push(item.prefLabel);
+                array.push({
+                    value: item[mapping.query],
+                    id: item[mapping.id]
+                });
+            });
+
+	    response( array );
+            console.log( array );
+        } 
+    })
+};
+
+function autoexample (request, response) {
+    $.ajax( {
+          url: "https://jqueryui.com/resources/demos/autocomplete/search.php",
+          dataType: "jsonp",
+          data: {
+            term: request.term
+          },
+          success: function( data ) {
+            response( data );
+            console.log( data );
+          }
+        } );
+};


### PR DESCRIPTION
How to test this

* Clone, built and deploy this war file
* Apply sql statements to update Dataverse database: 
`psql dvndb -f cv-update.sql`
Warning: dvndb is postgresql database, it can be different in your installation.
[cv-update.sql.zip](https://github.com/DANS-KNAW/dataverse/files/6188821/cv-update.sql.zip)
* Add this custom metadata block (cvocdemo.tsv) to Dataverse
See: http://guides.dataverse.org/en/latest/admin/metadatacustomization.html for an explanation of the steps to perform. 
[cvocdemo.tsv.zip](https://github.com/DANS-KNAW/dataverse/files/6188466/cvocdemo.tsv.zip)
* Enable the 'cvocDemo Metadata' Metadata Block for the dataverse where you are creating the dataset to test with
* Configure Dataverse to use the external-cvoc feature on the metdata block. 
The configuration is in a json file (cvoc-conf.json)
Run the following command to load the config into Dataverse
`curl -H "Content-Type: application/json" -X PUT -d @cvoc-conf.json http://localhost:8080/api/admin/settings/:CVocConf`
[cvoc-conf.json.zip](https://github.com/DANS-KNAW/dataverse/files/6188527/cvoc-conf.json.zip)
You can change the config and reload it to try different settings. For instance using only the unesco vocabulary with `"vocabs":["unesco"],` instead of `"vocabs":["unesco","stw","agrovoc"],`.

The Dataset creation form will now contain this extra block. 
Below some screenshots that show what it looks like in different settings. 
Without external cvoc enabled on it.
![Screenshot cvocDome-empty](https://user-images.githubusercontent.com/2151103/112136800-bff61a00-8bcf-11eb-9656-5df48e09c808.png)

With one vocab (unesco)
![Screenshot cvocDemo-one-vocab](https://user-images.githubusercontent.com/2151103/112136911-e74ce700-8bcf-11eb-8258-0e8dcd202b58.png)

With several vocabs
![Screenshot cvocDemo-multi-vocabs](https://user-images.githubusercontent.com/2151103/112137009-05b2e280-8bd0-11eb-9770-227d278dbfc0.png)


Description of the configuration settings

* vocab-name
  Name of the compound metadata field (Need to check usage in the code)
  
* cvoc-url
URL of the external vocabulary service that will provide the terms and URI's in the autocomplete
Must now be a SKOSMOS service, because that API is the only one supported by the cvoc-interface.js code; see "js-url" property. 
   
* language
Specifies the language for the terms (prefLabel in SKOS) to be retrieved. 
By default it's using the language of the server (calling BundleUtil.getDefaultLocale().getLanguage())

* js-url
This is the URL that the AJAX code will use to do the requests. It can be an external service, but a simple javascript 'wrapper' around the SKOSMOS API is now being used.  
Default is the application resource at: /resources/js/cvoc-interface.js
  
* protocol
Note that only "skosmos" is supported in the cvoc-interface.js. The default is also "skosmos".
  
* vocab-uri
The URI of the vocab, this is now only a single value but should be an array corresponding with the "vocabs" array.  (Note that it is an URL we want to put in that input field)
  
* term-parent-uri
The URI of the 'parent' concept acting as a filter for the terms to be retrieved allowing only narrower terms. This enables us to use a 'branch' of a large vocabulary without constructing separate vocabularies for subsets.    
  
* vocabs
The list of vocabularies. This should be the 'identifying' names in SKOSMOS. 

* vocab-codes
The input field names as specified in the metadata block. The order of the fields must be; vocabulary, term, termURI, VocabularyURI. 

* minChars
  Number of characters that must be typed in the 'term' field for the AJAX 'search' request to be sent. Use this with large vocabularies and set it to more characters (1 is usually enough) if the server does not respond fast enough. When it is 0 (default), the complete list will dropdown when the up or down arrow keys are typed. 
  
* readonly
Specify if the URL fields should be readonly. Also the vocabulary field is readonly when there is only one vocab configured. The default is false, allowing to type anything into the fields.   
  
* hideReadonlyUrls
When in 'readonly' the URL fields are now also hidden on the form. This makes the form more compact and simpler. The default is false, showing all the fields.
   