### PR TITLE
DD-425 missing error messages

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -55,6 +55,7 @@ public class LicenseServiceBean {
     public License save(License license) throws PersistenceException, RequestBodyException {
         if (license.getId() == null) {
             em.persist(license);
+            em.flush();
             return license;
         } else {
             throw new RequestBodyException("There shouldn't be an ID in the request body");


### PR DESCRIPTION
**What this PR does / why we need it**: Handles POSTing the same JSON twice

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**: POST this same JSON twice:
```
{
    "name": "Apache License 6.0",
    "shortDescription": "This is the original Apache License which applies only to very old versions of Apache packages (such as version 1.3 of the Web server).",
    "uri": "https://www.apache.org/licenses/LICENSE-6.0",
    "iconUrl": "https://itgala.xyz/wp-content/uploads/2016/10/Apache-HTTP-Server.png",
    "active": false
}
```

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
