### PR TITLE
DD-455 Configurable Account/Password Upgrade Page

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/LoginPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LoginPage.java
@@ -7,6 +7,7 @@ import edu.harvard.iq.dataverse.authorization.AuthenticationResponse;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
 import edu.harvard.iq.dataverse.authorization.CredentialsAuthenticationProvider;
 import edu.harvard.iq.dataverse.authorization.exceptions.AuthenticationFailedException;
+import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinAuthenticationProvider;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUserServiceBean;
 import edu.harvard.iq.dataverse.authorization.providers.shib.ShibAuthenticationProvider;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
@@ -159,12 +160,16 @@ public class LoginPage implements java.io.Serializable {
         
         AuthenticationRequest authReq = new AuthenticationRequest();
         List<FilledCredential> filledCredentialsList = getFilledCredentials();
+        boolean silentPasswordAlgorithmUpdate = settingsService.isTrueForKey(SettingsServiceBean.Key.SilentPasswordAlgorithmUpdateEnabled, false);
         if ( filledCredentialsList == null ) {
             logger.info("Credential list is null!");
             return null;
         }
         for ( FilledCredential fc : filledCredentialsList ) {       
             authReq.putCredential(fc.getCredential().getKey(), fc.getValue());
+        }
+        if (silentPasswordAlgorithmUpdate){
+            FacesContext.getCurrentInstance().getExternalContext().getFlash().put("silentUpgradePasswd",authReq.getCredential(BuiltinAuthenticationProvider.KEY_PASSWORD));
         }
         authReq.setIpAddress( dvRequestService.getDataverseRequest().getSourceAddress() );
         try {

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetPage.java
@@ -91,6 +91,8 @@ public class PasswordResetPage implements java.io.Serializable {
     String newPassword;
     
     PasswordResetData passwordResetData;
+
+    boolean validationFailed;
     
     private List<String> passwordErrors;
 
@@ -102,7 +104,7 @@ public class PasswordResetPage implements java.io.Serializable {
                 user = passwordResetData.getBuiltinUser();
                 if (passwordResetData.getReason().equals(PasswordResetData.Reason.UPGRADE_REQUIRED)){
                     newPassword = (String) FacesContext.getCurrentInstance().getExternalContext().getFlash().get("silentUpgradePasswd");
-                    FacesContext.getCurrentInstance().getExternalContext().getFlash().remove("silentUpgradePasswd");
+                    validationFailed = false;
                 }
             } else {
                 FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, 
@@ -147,6 +149,7 @@ public class PasswordResetPage implements java.io.Serializable {
 
     public String resetPassword() {
         PasswordChangeAttemptResponse response = passwordResetService.attemptPasswordReset(user, newPassword, this.token);
+        validationFailed = response.getMessageDetail().contains("Password Reset Problem");
         if (response.isChanged()) {
             FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, response.getMessageSummary(), response.getMessageDetail()));
             String builtinAuthProviderId = BuiltinAuthenticationProvider.PROVIDER_ID;
@@ -200,6 +203,10 @@ public class PasswordResetPage implements java.io.Serializable {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public boolean isFailedValidation(){
+        return validationFailed;
     }
 
     public BuiltinUser getUser() {

--- a/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/passwordreset/PasswordResetPage.java
@@ -100,6 +100,10 @@ public class PasswordResetPage implements java.io.Serializable {
             passwordResetData = passwordResetExecResponse.getPasswordResetData();
             if (passwordResetData != null) {
                 user = passwordResetData.getBuiltinUser();
+                if (passwordResetData.getReason().equals(PasswordResetData.Reason.UPGRADE_REQUIRED)){
+                    newPassword = (String) FacesContext.getCurrentInstance().getExternalContext().getFlash().get("silentUpgradePasswd");
+                    FacesContext.getCurrentInstance().getExternalContext().getFlash().remove("silentUpgradePasswd");
+                }
             } else {
                 FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, 
                         BundleUtil.getStringFromBundle("passwdVal.passwdReset.resetLinkTitle"),
@@ -230,6 +234,10 @@ public class PasswordResetPage implements java.io.Serializable {
         this.passwordResetData = passwordResetData;
     }
 
+    public boolean isSilentPasswordAlgorithmUpdateEnabled(){
+        return settingsWrapper.isTrueForKey(SettingsServiceBean.Key.SilentPasswordAlgorithmUpdateEnabled, false);
+    }
+
     public String getGoodPasswordDescription() {
         // FIXME: Pass the errors in.
         return passwordValidatorService.getGoodPasswordDescription(null);
@@ -240,8 +248,24 @@ public class PasswordResetPage implements java.io.Serializable {
         if(customPasswordResetAlertMessage != null && !customPasswordResetAlertMessage.isEmpty()){
             return customPasswordResetAlertMessage;
         } else {
-            String defaultPasswordResetAlertMessage = BundleUtil.getStringFromBundle("passwdReset.newPasswd.details");
-            return defaultPasswordResetAlertMessage;
+            return BundleUtil.getStringFromBundle("passwdReset.newPasswd.details");
+        }
+    }
+
+    public String getCustomPasswordResetAlertIntro() {
+        String customPasswordResetAlertIntro = settingsWrapper.getValueForKey(SettingsServiceBean.Key.CustomPasswordResetAlertIntro);
+        if(customPasswordResetAlertIntro != null && !customPasswordResetAlertIntro.isEmpty()){
+            return customPasswordResetAlertIntro;
+        } else {
+            return BundleUtil.getStringFromBundle("passwdReset.alert.intro");
+        }
+    }
+    public String getCustomPasswordResetButton() {
+        String customPasswordResetButton = settingsWrapper.getValueForKey(SettingsServiceBean.Key.CustomPasswordResetButton);
+        if(customPasswordResetButton != null && !customPasswordResetButton.isEmpty()){
+            return customPasswordResetButton;
+        } else {
+            return BundleUtil.getStringFromBundle("passwdReset.resetBtn");
         }
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -333,6 +333,10 @@ public class SettingsServiceBean {
          * Configurable text for alert/info message on passwordreset.xhtml when users are required to update their password.
          */
         PVCustomPasswordResetAlertMessage,
+        /**
+         * Set silent upgrade of password algorithm.
+         */
+        SilentPasswordAlgorithmUpdateEnabled,
         /*
         String to describe DOI format for data files. Default is DEPENDENT. 
         'DEPENEDENT' means the DOI will be the Dataset DOI plus a file DOI with a slash in between.
@@ -433,8 +437,11 @@ public class SettingsServiceBean {
          * Installation Brand Name is always included (default/false) or is not included
          * when the Distributor field (citation metadatablock) is set (true)
          */
-        ExportInstallationAsDistributorOnlyWhenNotSet
-        ;
+        ExportInstallationAsDistributorOnlyWhenNotSet,
+        /**
+         * Configurable text for alert/info message on passwordreset.xhtml when users are required to update their password.
+         */
+        CustomPasswordResetAlertIntro, CustomPasswordResetButton;
 
         @Override
         public String toString() {

--- a/src/main/java/propertyFiles/Bundle.properties
+++ b/src/main/java/propertyFiles/Bundle.properties
@@ -294,6 +294,7 @@ passwdReset.resetUrl=The reset URL is
 passwdReset.noEmail.tip=No email was actually sent because a user could not be found using the provided email address {0} but we don't mention this because we don't malicious users to use the form to determine if there is an account associated with an email address.
 passwdReset.illegalLink.tip=Your password reset link is not valid. If you need to reset your password, {0}click here{1} in order to request that your password to be reset again.
 passwdReset.newPasswd.details={0} Reset Password{1} \u2013 Our password requirements have changed. Please pick a strong password that matches the criteria below.
+passwdReset.alert.intro=Please accept our new Terms of Use.  Also, note that you can connect your account to your institutional account, or ORCID, Google or GitHub account. To do so, log out after completing this step. Log in again with one of “Log in with our institutional account”, “ORCID”, “Google” or “GitHub”. 
 passwdReset.newPasswd=New Password
 passwdReset.rePasswd=Retype Password
 passwdReset.resetBtn=Reset Password

--- a/src/main/webapp/passwordreset.xhtml
+++ b/src/main/webapp/passwordreset.xhtml
@@ -108,7 +108,7 @@
                         <div>
                             <h:form id="passwordResetForm" styleClass="form-horizontal">
                                 <p:focus context="passwordResetForm"/>
-                                <div class="form-group col-sm-11" jsf:rendered="#{not PasswordResetPage.isSilentPasswordAlgorithmUpdateEnabled()}">
+                                <div class="form-group col-sm-11" jsf:rendered="#{!PasswordResetPage.isSilentPasswordAlgorithmUpdateEnabled() || PasswordResetPage.isFailedValidation()}">
                                     <label for="inputPassword" class="col-sm-3 control-label">
                                         #{bundle['passwdReset.newPasswd']} <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"></span>
                                     </label>
@@ -124,7 +124,7 @@
 					<p:message for="inputPassword"/>
                                     </div>
                                 </div>
-                                <div class="form-group col-sm-11" jsf:rendered="#{not PasswordResetPage.isSilentPasswordAlgorithmUpdateEnabled()}">
+                                <div class="form-group col-sm-11" jsf:rendered="#{!PasswordResetPage.isSilentPasswordAlgorithmUpdateEnabled() || PasswordResetPage.isFailedValidation()}">
                                     <label for="retypePassword" class="col-sm-3 control-label">
                                         #{bundle['passwdReset.rePasswd']} <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"></span>
                                     </label>

--- a/src/main/webapp/passwordreset.xhtml
+++ b/src/main/webapp/passwordreset.xhtml
@@ -102,13 +102,13 @@
                                 <h:outputFormat styleClass="h2 text-info show" value="#{bundle['user.updatePassword.welcome']}">
                                     <f:param value="#{systemConfig.getVersion(true)}"/>
                                 </h:outputFormat>
-                                <p class="help-block"><span class="text-danger"><span class="glyphicon glyphicon-warning-sign"/> #{bundle['user.updatePassword.warning']}</span></p>
+                                <p class="help-block"><span class="text-danger"><span class="glyphicon glyphicon-warning-sign"/> #{PasswordResetPage.customPasswordResetAlertIntro}</span></p>
                             </div>
                         </div>
                         <div>
                             <h:form id="passwordResetForm" styleClass="form-horizontal">
                                 <p:focus context="passwordResetForm"/>
-                                <div class="form-group col-sm-11">
+                                <div class="form-group col-sm-11" jsf:rendered="#{not PasswordResetPage.isSilentPasswordAlgorithmUpdateEnabled()}">
                                     <label for="inputPassword" class="col-sm-3 control-label">
                                         #{bundle['passwdReset.newPasswd']} <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"></span>
                                     </label>
@@ -124,7 +124,7 @@
 					<p:message for="inputPassword"/>
                                     </div>
                                 </div>
-                                <div class="form-group col-sm-11">
+                                <div class="form-group col-sm-11" jsf:rendered="#{not PasswordResetPage.isSilentPasswordAlgorithmUpdateEnabled()}">
                                     <label for="retypePassword" class="col-sm-3 control-label">
                                         #{bundle['passwdReset.rePasswd']} <span class="glyphicon glyphicon-asterisk text-danger" title="#{bundle.requiredField}"></span>
                                     </label>
@@ -139,7 +139,7 @@
                                 </ui:fragment>
                                 <div class="form-group col-sm-11">
                                     <div class="col-sm-10 button-block">
-                                        <p:commandButton styleClass="btn btn-default" action="#{PasswordResetPage.resetPassword()}" update="@all" value="#{bundle['passwdReset.resetBtn']}"/>
+                                        <p:commandButton styleClass="btn btn-default" action="#{PasswordResetPage.resetPassword()}" update="@all" value="#{PasswordResetPage.customPasswordResetButton}"/>
                                     </div>
                                 </div>
                             </h:form>


### PR DESCRIPTION
This approach tries to combine the `FaceContext.getFlash()` approach with the check if `:SilentPasswordAlgorithmUpdateEnabled` function from Jim's approach. 

The Password Reset Page is configurable with the following commands:
```bash
curl -X PUT -d "true" http://localhost:8080/api/admin/settings/:SilentPasswordAlgorithmUpdateEnabled

dataverse/scripts/installer/custom-build-number Easy User Migration

curl -X PUT -d '{0} Our Terms of Use have been updated:{1} Please check the box below and click Continue' http://localhost:8080/api/admin/settings/:PVCustomPasswordResetAlertMessage

curl -X PUT -d "Continue" http://localhost:8080/api/admin/settings/:CustomPasswordResetButton

curl -X PUT -d 'Please accept our new Terms of Use.  Also, note that you can connect your account to your institutional account, or ORCID, Google or GitHub account. To do so, log out after completing this step. Log in again with one of “Log in with our institutional account”, “ORCID”, “Google” or “GitHub”. ' http://localhost:8080/api/admin/settings/:CustomPasswordResetAlertIntro
```

![image](https://user-images.githubusercontent.com/56864998/118972662-1504a100-b971-11eb-8596-c579aec5028f.png)


The Password Reset Page does not render the password input fields if `:SilentPasswordAlgorithmUpdateEnabled is true`


There's still a concern regarding Password Validation, are the Easy User passwords using safe standards? 
Or is that of no concern because it's a gateway to Federative Login?
If validation fails there is no solution in place to allow Password Input here.
@janvanmansum @PaulBoon 