### PR TITLE
DD-484 empty custom license only fields before saving standard license

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -3606,6 +3606,7 @@ public class DatasetPage implements java.io.Serializable {
         } else {
             License license = licenseServiceBean.getById(licenseId);
             terms.setLicense(license);
+            terms.clearCustomTermsVariables();
         }
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/TermsOfUseAndAccess.java
+++ b/src/main/java/edu/harvard/iq/dataverse/TermsOfUseAndAccess.java
@@ -278,6 +278,17 @@ public class TermsOfUseAndAccess implements Serializable {
         edu.harvard.iq.dataverse.License license = new edu.harvard.iq.dataverse.License("CC0", shortDescription, uri, iconUrl, true);
         return license;
     }
+
+    public void clearCustomTermsVariables(){
+        termsOfUse = null;
+        confidentialityDeclaration = null;
+        specialPermissions = null;
+        restrictions = null;
+        citationRequirements = null;
+        depositorRequirements = null;
+        conditions = null;
+        disclaimer = null;
+    }
     
     /**
      * @todo What does the GUI use for a default license? What does the "native"


### PR DESCRIPTION
Reproduce bug:
1. In a Dataset go to the Terms tab and select Edit Terms Requirements
2. Select Custom License and add text to 1 or more fields.
3. Switch to a Standard License first, then back to Custom License
4. Observe that added text is still there.
5. Switch to Standard License again and Save Changes

Previous steps would cause Custom Fields to be stored even when a Standard License was selected.
Probably caused by the `value="#{termsOfUseAndAccess.setterFunctions}"` in `dataset-license-terms.xhtml`, the function probably triggers when you select a different license from the drop-down menu. 

This PR fixes that.
