### PR TITLE
DD-511 Open links to license in new tab

### DIFF
--- a/src/main/resources/db/migration/V5.5.0.3__7440-multi-license-add-column-to-termsofuseandaccess.sql
+++ b/src/main/resources/db/migration/V5.5.0.3__7440-multi-license-add-column-to-termsofuseandaccess.sql
@@ -1,4 +1,13 @@
 
 ALTER TABLE termsofuseandaccess ADD COLUMN IF NOT EXISTS license_id BIGINT;
 
-ALTER TABLE termsofuseandaccess ADD CONSTRAINT fk_termsofuseandcesss_license_id foreign key (license_id) REFERENCES license(id);
+DO $$
+BEGIN
+
+  BEGIN
+    ALTER TABLE termsofuseandaccess ADD CONSTRAINT fk_termsofuseandcesss_license_id foreign key (license_id) REFERENCES license(id);
+  EXCEPTION
+    WHEN duplicate_object THEN RAISE NOTICE 'Table constraint fk_termsofuseandcesss_license_id already exists';
+  END;
+
+END $$;

--- a/src/main/webapp/dataset-license-terms.xhtml
+++ b/src/main/webapp/dataset-license-terms.xhtml
@@ -52,13 +52,13 @@
                                <ui:fragment rendered="#{!empty termsOfUseAndAccess.license and empty DatasetPage.licenseId and empty editMode}">
                                        <p>
                                            <img src="#{termsOfUseAndAccess.license.iconUrl}" alt="#{bundle['file.icon.alttxt']}" width="15%" height="15%"/>
-                                           <a href="#{termsOfUseAndAccess.license.uri}">#{termsOfUseAndAccess.license.name}</a>
+                                           <a href="#{termsOfUseAndAccess.license.uri}" target="_blank">#{termsOfUseAndAccess.license.name}</a>
                                        </p>
                                </ui:fragment>
                                <ui:fragment rendered="#{!empty DatasetPage.licenseId}">
                                    <p >
                                        <img src="#{DatasetPage.getSelectedLicenseById().iconUrl}" alt="#{bundle['file.icon.alttxt']}" width="15%" height="15%"/>
-                                       <a href="#{DatasetPage.getSelectedLicenseById().uri}">#{DatasetPage.getSelectedLicenseById().name}</a>
+                                       <a href="#{DatasetPage.getSelectedLicenseById().uri}" target="_blank">#{DatasetPage.getSelectedLicenseById().name}</a>
                                    </p>
                                </ui:fragment>
                            </div>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -599,7 +599,7 @@
                                                         <ui:fragment rendered="#{!empty DatasetPage.workingVersion.termsOfUseAndAccess.license}">
                                                             <p>
                                                                 <img src="#{DatasetPage.workingVersion.termsOfUseAndAccess.license.iconUrl}" alt="#{bundle['file.icon.alttxt']}" width="15%" height="15%"/>
-                                                                <a href="#{DatasetPage.workingVersion.termsOfUseAndAccess.license.uri}">#{DatasetPage.workingVersion.termsOfUseAndAccess.license.name}</a>
+                                                                <a href="#{DatasetPage.workingVersion.termsOfUseAndAccess.license.uri}" target="_blank">#{DatasetPage.workingVersion.termsOfUseAndAccess.license.name}</a>
                                                             </p>
                                                         </ui:fragment>
                                                         <ui:fragment rendered="#{empty DatasetPage.workingVersion.termsOfUseAndAccess.license}">
@@ -1624,7 +1624,7 @@
                                     <ui:fragment rendered="#{!empty DatasetPage.workingVersion.termsOfUseAndAccess.license}">
                                         <p>
                                             <img src="#{DatasetPage.workingVersion.termsOfUseAndAccess.license.iconUrl}" alt="#{bundle['file.icon.alttxt']}" width="15%" height="15%"/>
-                                            <a href="#{DatasetPage.workingVersion.termsOfUseAndAccess.license.uri}">#{DatasetPage.workingVersion.termsOfUseAndAccess.license.name}</a>
+                                            <a href="#{DatasetPage.workingVersion.termsOfUseAndAccess.license.uri}" target="_blank">#{DatasetPage.workingVersion.termsOfUseAndAccess.license.name}</a>
                                         </p>
                                     </ui:fragment>
                                 </div>


### PR DESCRIPTION
* Made sure external links to license information are opened in a separated tab.
* Piggybacking an improvement to the flyway script (suggested by @qqmyers) onto this PR.