### PR TITLE
DD-521 Default license

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -1,9 +1,5 @@
 package edu.harvard.iq.dataverse;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -14,6 +10,10 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Jing Ma
@@ -26,13 +26,18 @@ import javax.persistence.UniqueConstraint;
     @NamedQuery( name="License.findById",
             query = "SELECT l FROM License l WHERE l.id=:id"),
     @NamedQuery( name="License.findDefault",
-            query = "SELECT l FROM License l WHERE l.name='CC0'"),
+            query = "SELECT l FROM License l WHERE l.isDefault='true' "),
     @NamedQuery( name="License.findByNameOrUri",
             query = "SELECT l FROM License l WHERE l.name=:name OR l.uri=:uri"),
     @NamedQuery( name="License.deleteById",
-                query="DELETE FROM License l WHERE l.id=:id"),
+            query = "DELETE FROM License l WHERE l.id=:id"),
     @NamedQuery( name="License.deleteByName",
-                query="DELETE FROM License l WHERE l.name=:name")
+            query = "DELETE FROM License l WHERE l.name=:name"),
+    @NamedQuery( name="License.setDefault",
+            query = "UPDATE License l SET isDefault='true' WHERE l.id=:id"),
+    @NamedQuery( name="License.clearDefault",
+                query = "UPDATE License SET isDefault='false'"),
+
 })
 @Entity
 @Table(uniqueConstraints = {
@@ -57,6 +62,9 @@ public class License {
 
     @Column(nullable = false)
     private boolean active;
+
+    @Column(nullable = false)
+    private boolean isDefault;
     
     @OneToMany(mappedBy="license")
     private List<TermsOfUseAndAccess> termsOfUseAndAccess;
@@ -69,6 +77,7 @@ public class License {
         this.uri = uri.toASCIIString();
         this.iconUrl = iconUrl.toASCIIString();
         this.active = active;
+        isDefault = false;
     }
 
     public Long getId() {
@@ -119,6 +128,14 @@ public class License {
         this.active = active;
     }
 
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    public void setDefault(boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
     public List<TermsOfUseAndAccess> getTermsOfUseAndAccess() {
         return termsOfUseAndAccess;
     }
@@ -148,6 +165,7 @@ public class License {
                 ", uri=" + uri +
                 ", iconUrl=" + iconUrl +
                 ", active=" + active +
+                ", isDefault=" + isDefault +
                 '}';
     }
     

--- a/src/main/java/edu/harvard/iq/dataverse/License.java
+++ b/src/main/java/edu/harvard/iq/dataverse/License.java
@@ -34,9 +34,9 @@ import java.util.Objects;
     @NamedQuery( name="License.deleteByName",
             query = "DELETE FROM License l WHERE l.name=:name"),
     @NamedQuery( name="License.setDefault",
-            query = "UPDATE License l SET isDefault='true' WHERE l.id=:id"),
+            query = "UPDATE License l SET l.isDefault='true' WHERE l.id=:id"),
     @NamedQuery( name="License.clearDefault",
-                query = "UPDATE License SET isDefault='false'"),
+                query = "UPDATE License l SET l.isDefault='false'"),
 
 })
 @Entity

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -49,20 +49,25 @@ public class LicenseServiceBean {
         return licenses.get(0);
     }
 
-    public License getByName(String name) throws FetchException {
-        List<License> licenses = em.createNamedQuery("License.findByName", License.class)
-                .setParameter("name", name )
-                .getResultList();
-        if (licenses.isEmpty()) {
-            throw new FetchException("License with that name doesn't exist.");
-        }
-        return licenses.get(0);
-    }
-
     public License getDefault() {
         List<License> licenses = em.createNamedQuery("License.findDefault", License.class)
                 .getResultList();
         return licenses.get(0);
+    }
+
+    public void setDefault(Long id) throws UpdateException, FetchException {
+        License candidate = getById(id);
+        if (candidate.isActive()) {
+            try {
+                em.createNamedQuery("License.clearDefault");
+                em.createNamedQuery("License.setDefault").setParameter("id", id);
+            }
+            catch (PersistenceException e) {
+                throw new UpdateException("Could not change default license");
+            }
+        }
+        else
+            throw new IllegalArgumentException("Cannot set an inactive license as default");
     }
 
     public License save(License license) throws RequestBodyException, ConflictException {

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -63,7 +63,7 @@ public class LicenseServiceBean {
                 em.createNamedQuery("License.setDefault").setParameter("id", id);
             }
             catch (PersistenceException e) {
-                throw new UpdateException("Could not change default license");
+                throw new UpdateException("Inactive license cannot be default.");
             }
         }
         else

--- a/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/LicenseServiceBean.java
@@ -59,8 +59,8 @@ public class LicenseServiceBean {
         License candidate = getById(id);
         if (candidate.isActive()) {
             try {
-                em.createNamedQuery("License.clearDefault");
-                em.createNamedQuery("License.setDefault").setParameter("id", id);
+                em.createNamedQuery("License.clearDefault").executeUpdate();
+                em.createNamedQuery("License.setDefault").setParameter("id", id).executeUpdate();
             }
             catch (PersistenceException e) {
                 throw new UpdateException("Inactive license cannot be default.");

--- a/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Admin.java
@@ -1,6 +1,5 @@
 package edu.harvard.iq.dataverse.api;
 
-import com.google.common.net.UrlEscapers;
 import edu.harvard.iq.dataverse.BannerMessage;
 import edu.harvard.iq.dataverse.BannerMessageServiceBean;
 import edu.harvard.iq.dataverse.BannerMessageText;
@@ -17,18 +16,23 @@ import edu.harvard.iq.dataverse.DvObject;
 import edu.harvard.iq.dataverse.EMailValidator;
 import edu.harvard.iq.dataverse.EjbDataverseEngine;
 import edu.harvard.iq.dataverse.GlobalId;
-import edu.harvard.iq.dataverse.RoleAssignment;
 import edu.harvard.iq.dataverse.License;
 import edu.harvard.iq.dataverse.LicenseServiceBean;
 import edu.harvard.iq.dataverse.UserServiceBean;
 import edu.harvard.iq.dataverse.actionlogging.ActionLogRecord;
 import edu.harvard.iq.dataverse.api.dto.RoleDTO;
+import edu.harvard.iq.dataverse.authorization.AuthTestDataServiceBean;
 import edu.harvard.iq.dataverse.authorization.AuthenticatedUserDisplayInfo;
 import edu.harvard.iq.dataverse.authorization.AuthenticationProvider;
+import edu.harvard.iq.dataverse.authorization.AuthenticationProvidersRegistrationServiceBean;
+import edu.harvard.iq.dataverse.authorization.DataverseRole;
+import edu.harvard.iq.dataverse.authorization.RoleAssignee;
 import edu.harvard.iq.dataverse.authorization.UserIdentifier;
+import edu.harvard.iq.dataverse.authorization.UserRecordIdentifier;
 import edu.harvard.iq.dataverse.authorization.exceptions.AuthenticationProviderFactoryNotFoundException;
 import edu.harvard.iq.dataverse.authorization.exceptions.AuthorizationSetupException;
 import edu.harvard.iq.dataverse.authorization.groups.GroupServiceBean;
+import edu.harvard.iq.dataverse.authorization.groups.impl.explicit.ExplicitGroupServiceBean;
 import edu.harvard.iq.dataverse.authorization.providers.AuthenticationProviderRow;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUser;
 import edu.harvard.iq.dataverse.authorization.providers.builtin.BuiltinUserServiceBean;
@@ -36,85 +40,75 @@ import edu.harvard.iq.dataverse.authorization.providers.shib.ShibAuthenticationP
 import edu.harvard.iq.dataverse.authorization.providers.shib.ShibServiceBean;
 import edu.harvard.iq.dataverse.authorization.providers.shib.ShibUtil;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
+import edu.harvard.iq.dataverse.authorization.users.User;
 import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailData;
 import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailException;
 import edu.harvard.iq.dataverse.confirmemail.ConfirmEmailInitResponse;
 import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import edu.harvard.iq.dataverse.dataaccess.DataAccessOption;
-import edu.harvard.iq.dataverse.dataaccess.StorageIO;
-import edu.harvard.iq.dataverse.engine.command.impl.AbstractSubmitToArchiveCommand;
-import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
-import edu.harvard.iq.dataverse.settings.Setting;
-import edu.harvard.iq.dataverse.util.json.JsonPrinter;
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObjectBuilder;
-import javax.persistence.PersistenceException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Response;
-import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
-import static edu.harvard.iq.dataverse.util.json.JsonPrinter.*;
-
-import java.io.InputStream;
-import java.io.StringReader;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response.Status;
-
-import org.apache.commons.io.IOUtils;
-
-import java.util.List;
-import edu.harvard.iq.dataverse.authorization.AuthTestDataServiceBean;
-import edu.harvard.iq.dataverse.authorization.AuthenticationProvidersRegistrationServiceBean;
-import edu.harvard.iq.dataverse.authorization.DataverseRole;
-import edu.harvard.iq.dataverse.authorization.RoleAssignee;
-import edu.harvard.iq.dataverse.authorization.UserRecordIdentifier;
-import edu.harvard.iq.dataverse.authorization.groups.impl.explicit.ExplicitGroupServiceBean;
-import edu.harvard.iq.dataverse.authorization.users.User;
 import edu.harvard.iq.dataverse.dataaccess.ImageThumbConverter;
+import edu.harvard.iq.dataverse.dataaccess.StorageIO;
 import edu.harvard.iq.dataverse.dataset.DatasetThumbnail;
 import edu.harvard.iq.dataverse.dataset.DatasetUtil;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
 import edu.harvard.iq.dataverse.engine.command.exception.CommandException;
-import edu.harvard.iq.dataverse.engine.command.impl.MergeInAccountCommand;
-import edu.harvard.iq.dataverse.engine.command.impl.ChangeUserIdentifierCommand;
+import edu.harvard.iq.dataverse.engine.command.impl.AbstractSubmitToArchiveCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.DeactivateUserCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.DeleteRoleCommand;
+import edu.harvard.iq.dataverse.engine.command.impl.PublishDataverseCommand;
 import edu.harvard.iq.dataverse.engine.command.impl.RegisterDvObjectCommand;
 import edu.harvard.iq.dataverse.ingest.IngestServiceBean;
+import edu.harvard.iq.dataverse.settings.Setting;
 import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.userdata.UserListMaker;
 import edu.harvard.iq.dataverse.userdata.UserListResult;
 import edu.harvard.iq.dataverse.util.ArchiverUtil;
 import edu.harvard.iq.dataverse.util.BundleUtil;
 import edu.harvard.iq.dataverse.util.FileUtil;
-import java.io.IOException;
-import java.io.OutputStream;
+import edu.harvard.iq.dataverse.util.json.JsonPrinter;
+import org.apache.commons.io.IOUtils;
 
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
+import javax.persistence.Query;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import javax.inject.Inject;
-import javax.json.JsonArray;
-import javax.persistence.Query;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.StreamingOutput;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static edu.harvard.iq.dataverse.util.json.JsonPrinter.json;
+import static edu.harvard.iq.dataverse.util.json.JsonPrinter.rolesToJson;
+import static edu.harvard.iq.dataverse.util.json.JsonPrinter.toJsonArray;
+import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
 
 /**
  * Where the secure, setup API calls live.
@@ -2007,6 +2001,23 @@ public class Admin extends AbstractApiBean {
             return error(Response.Status.BAD_REQUEST, e.getMessage());
         } catch(ConflictException e) {
             return error(Response.Status.CONFLICT, e.getMessage());
+        }
+    }
+
+    // TODO: GET /licenses/default
+
+    @PUT
+    @Path("/licenses/default")
+    public Response setDefault(long id) {
+        try {
+            licenseService.setDefault(id);
+            return ok("Default license ID set to " + id);
+        }
+        catch (UpdateException | FetchException e) {
+            return error(Status.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+        catch (IllegalArgumentException e) {
+            return badRequest(e.getMessage());
         }
     }
 

--- a/src/main/resources/db/migration/V5.5.0.3__7440-configurable-license-list.sql
+++ b/src/main/resources/db/migration/V5.5.0.3__7440-configurable-license-list.sql
@@ -11,7 +11,7 @@ BEGIN
   END;
 
   BEGIN
-      INSERT INTO license (uri, name, active, iconurl) VALUES ('http://creativecommons.org/publicdomain/zero/1.0', 'CC0', true, '/resources/images/cc0.png');
+      INSERT INTO license (uri, name, active, isDefault, iconurl) VALUES ('http://creativecommons.org/publicdomain/zero/1.0', 'CC0', true, true, '/resources/images/cc0.png');
   EXCEPTION
     WHEN duplicate_object THEN RAISE NOTICE 'CC0 has already been added to the license table';
   END;


### PR DESCRIPTION
Fixes DD-512

# Description of changes
* Added column `isDefault` to the `license` table.
* Added API endpoint for setting default license as specified in DD-520 (see comment of 2021-06-22).

# How to test
1. Start with base box with Dataverse v5.5 on it (not the DANS-DataStation branch because the database update will probably not work when starting from the license table without the extra column)
2. Build this PR
3. Deploy the new war
4. Add an extra license, for example:
   ```json
   {
    "name": "CC-BY",
    "uri": "http://creativecommons.org/licenses/by/4.0",
    "iconUrl": "https://licensebuttons.net/l/by/3.0/88x31.png",
    "active": true
   }
   ```

5. Set the default to this new license: `curl -X PUT -H 'Content-Type: text/plain' -d <id>  http://localhost:8080/api/admin/licenses/default` (set `<id>` to the id of the new license).
6. Create a new dataset and check that by default the license is set correctly.

# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
