### PR TITLE
DD-527 Restructure license and custom terms in dataset JSON

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersion.java
@@ -160,6 +160,9 @@ public class DatasetVersion implements Serializable {
 
     @Transient
     private String contributorNames;
+
+    @Transient
+    private final String dataverseSiteUrl = SystemConfig.getDataverseSiteUrlStatic();
     
     @Transient 
     private String jsonLd;
@@ -198,7 +201,11 @@ public class DatasetVersion implements Serializable {
 
     public void setVersion(Long version) {
     }
-    
+
+    public String getDataverseSiteUrl() {
+        return dataverseSiteUrl;
+    }
+
     public List<FileMetadata> getFileMetadatas() {
         return fileMetadatas;
     }

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -43,6 +43,8 @@ import edu.harvard.iq.dataverse.settings.SettingsServiceBean;
 import edu.harvard.iq.dataverse.util.DatasetFieldWalker;
 import edu.harvard.iq.dataverse.util.StringUtil;
 import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
+
+import edu.harvard.iq.dataverse.util.SystemConfig;
 import edu.harvard.iq.dataverse.workflow.Workflow;
 import edu.harvard.iq.dataverse.workflow.step.WorkflowStepData;
 
@@ -354,7 +356,9 @@ public class JsonPrinter {
                 .add("createTime", format(dsv.getCreateTime()))
                 .add("license", jsonObjectBuilder()
                         .add("label", dsv.getTermsOfUseAndAccess().getLicense() != null ? dsv.getTermsOfUseAndAccess().getLicense().getName() : "CUSTOM")
-                        .add("uri", dsv.getTermsOfUseAndAccess().getLicense() != null ? dsv.getTermsOfUseAndAccess().getLicense().getUri().toString() : "https://mydataverse.com/licenses/10.507/DAR/VKCWQ8/v2.1")) //TODO create proper URI for Custom terms
+                        .add("uri", dsv.getTermsOfUseAndAccess().getLicense() != null ? dsv.getTermsOfUseAndAccess().getLicense().getUri().toString() :
+                                (dsv.getVersionState().name().equals("DRAFT") ? dsv.getDataverseSiteUrl() + "/api/datasets/:persistentId/versions/:draft/customlicense?persistentId=" + dsv.getDataset().getGlobalId().asString() :
+                                        dsv.getDataverseSiteUrl() + "/api/datasets/:persistentId/versions/" + dsv.getVersionNumber() + "." + dsv.getMinorVersionNumber() + "/customlicense?persistentId=" + dsv.getDataset().getGlobalId().asString())))
                 .add("confidentialityDeclaration", dsv.getTermsOfUseAndAccess().getConfidentialityDeclaration() != null ? dsv.getTermsOfUseAndAccess().getConfidentialityDeclaration() : null)
                 .add("availabilityStatus", dsv.getTermsOfUseAndAccess().getAvailabilityStatus() != null ? dsv.getTermsOfUseAndAccess().getAvailabilityStatus() : null)
                 .add("specialPermissions", dsv.getTermsOfUseAndAccess().getSpecialPermissions() != null ? dsv.getTermsOfUseAndAccess().getSpecialPermissions() : null)

--- a/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/json/JsonPrinter.java
@@ -352,8 +352,9 @@ public class JsonPrinter {
                 .add("lastUpdateTime", format(dsv.getLastUpdateTime()))
                 .add("releaseTime", format(dsv.getReleaseTime()))
                 .add("createTime", format(dsv.getCreateTime()))
-                .add("license", dsv.getTermsOfUseAndAccess().getLicense() != null ? dsv.getTermsOfUseAndAccess().getLicense().toString() : null)
-                .add("termsOfUse", getLicenseInfo(dsv))
+                .add("license", jsonObjectBuilder()
+                        .add("label", dsv.getTermsOfUseAndAccess().getLicense() != null ? dsv.getTermsOfUseAndAccess().getLicense().getName() : "CUSTOM")
+                        .add("uri", dsv.getTermsOfUseAndAccess().getLicense() != null ? dsv.getTermsOfUseAndAccess().getLicense().getUri().toString() : "https://mydataverse.com/licenses/10.507/DAR/VKCWQ8/v2.1")) //TODO create proper URI for Custom terms
                 .add("confidentialityDeclaration", dsv.getTermsOfUseAndAccess().getConfidentialityDeclaration() != null ? dsv.getTermsOfUseAndAccess().getConfidentialityDeclaration() : null)
                 .add("availabilityStatus", dsv.getTermsOfUseAndAccess().getAvailabilityStatus() != null ? dsv.getTermsOfUseAndAccess().getAvailabilityStatus() : null)
                 .add("specialPermissions", dsv.getTermsOfUseAndAccess().getSpecialPermissions() != null ? dsv.getTermsOfUseAndAccess().getSpecialPermissions() : null)


### PR DESCRIPTION
Create dataset with custom and standard license and use following curl command:
```
curl -s -H X-Dataverse-key:{apiToken} 'http://localhost:8080/api/datasets/:persistentId/versions/{:draft OR 1.0}?persistentId={doi:10.5072/DAR/BXBIEB}' | jq
```
Should result in:
```json
{
  "status": "OK",
  "data": {
    "id": 2,
    "datasetId": 3,
    "datasetPersistentId": "doi:10.5072/DAR/BXBIEB",
    "storageIdentifier": "s3://10.5072/DAR/BXBIEB",
    "versionState": "DRAFT",
    "lastUpdateTime": "2021-07-07T09:53:30Z",
    "createTime": "2021-07-07T09:37:17Z",
    "license": {
      "label": "CUSTOM",
      "uri": "https://dar.dans.knaw.nl/api/datasets/:persistentId/versions/:draft/customlicense?persistentId=doi:10.5072/DAR/BXBIEB"
    }, 
    ....
} 
```

