### PR TITLE
DD-526 create url for custom terms

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1861,15 +1861,20 @@ public class DatasetPage implements java.io.Serializable {
                 return permissionsWrapper.notFound();
             }
 
-            //if (session.getUser(true).isAuthenticated()) {
-                //setCurrentUser((AuthenticatedUser) session.getUser());
-                //userAuthProvider = authenticationService.lookupProvider(currentUser);
-
-                if (selectTab.equals("termsTab")){
-                    activeTabIndex = 2;
-                }
-            //}
-
+            switch (selectTab){
+                case "dataFilesTab":
+                    selectedTabIndex = 0;
+                    break;
+                case "metadataMapTab":
+                    selectedTabIndex = 1;
+                    break;
+                case "termsTab":
+                    selectedTabIndex = 2;
+                    break;
+                case "versionsTab":
+                    selectedTabIndex = 3;
+                    break;
+            }
 
             //this.dataset = this.workingVersion.getDataset();
 
@@ -2798,10 +2803,6 @@ public class DatasetPage implements java.io.Serializable {
         }
 
         displayWorkflowComments();
-
-        if (selectTab.equals("termsTab")){
-            activeTabIndex = 2;
-        }
 
         return "";
     }

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -247,6 +247,7 @@ public class DatasetPage implements java.io.Serializable {
     private Long ownerId;
     private Long versionId;
     private int selectedTabIndex;
+    private String selectTab = "";
     private List<DataFile> newFiles = new ArrayList<>();
     private List<DataFile> uploadedFiles = new ArrayList<>();
     private MutableBoolean uploadInProgress = new MutableBoolean(false);
@@ -1558,6 +1559,14 @@ public class DatasetPage implements java.io.Serializable {
         return selectedTabIndex;
     }
 
+    public String getSelectTab() {
+        return selectTab;
+    }
+
+    public void setSelectTab(String selectTab) {
+        this.selectTab = selectTab;
+    }
+
     public void setSelectedTabIndex(int selectedTabIndex) {
         this.selectedTabIndex = selectedTabIndex;
     }
@@ -1625,6 +1634,8 @@ public class DatasetPage implements java.io.Serializable {
     public void setSelectedTemplate(Template selectedTemplate) {
         this.selectedTemplate = selectedTemplate;
     }
+
+
 
     public void updateSelectedTemplate(ValueChangeEvent event) {
 
@@ -1849,6 +1860,15 @@ public class DatasetPage implements java.io.Serializable {
             if (retrieveDatasetVersionResponse == null) {
                 return permissionsWrapper.notFound();
             }
+
+            //if (session.getUser(true).isAuthenticated()) {
+                //setCurrentUser((AuthenticatedUser) session.getUser());
+                //userAuthProvider = authenticationService.lookupProvider(currentUser);
+
+                if (selectTab.equals("termsTab")){
+                    activeTabIndex = 2;
+                }
+            //}
 
 
             //this.dataset = this.workingVersion.getDataset();
@@ -2731,6 +2751,8 @@ public class DatasetPage implements java.io.Serializable {
             retrieveDatasetVersionResponse = datasetVersionService.selectRequestedVersion(dataset.getVersions(), version);
         }
 
+
+
         if (retrieveDatasetVersionResponse == null) {
             // TODO:
             // should probably redirect to the 404 page, if we can't find
@@ -2776,6 +2798,10 @@ public class DatasetPage implements java.io.Serializable {
         }
 
         displayWorkflowComments();
+
+        if (selectTab.equals("termsTab")){
+            activeTabIndex = 2;
+        }
 
         return "";
     }

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -1146,24 +1146,17 @@ public class Datasets extends AbstractApiBean {
 
     @GET
     @Path("{id}/versions/{versionId}/customlicense")
-    @Produces(MediaType.APPLICATION_XHTML_XML)
-    public Response getCustomTermsTab(@PathParam("id") String id, @PathParam("versionId") String versionId){
-        String persistentId = null;
-        if (id != null) {
-            if (id.equals(":persistentId")) {
-                persistentId = getRequestParameter(":persistentId".substring(1));
-                if (persistentId == null) {
-                    return error(Response.Status.BAD_REQUEST, "");
-                }
-            }
-        } else return error(Response.Status.BAD_REQUEST, "");
-
-        if (versionId == null) {
-            return error(Response.Status.BAD_REQUEST, "");
-        } else if (versionId.equals(":draft")){
-            versionId = "DRAFT";
+    public Response getCustomTermsTab(@PathParam("id") String id, @PathParam("versionId") String versionId, @Context UriInfo uriInfo, @Context HttpHeaders headers){
+        User user = session.getUser();
+        String persistentId;
+        try {
+            if (!user.isAuthenticated()) user = findAuthenticatedUserOrDie();
+            getDatasetVersionOrDie(createDataverseRequest(user), versionId, findDatasetOrDie(id), uriInfo, headers);
+            persistentId = getRequestParameter(":persistentId".substring(1));
+            if (versionId.equals(":draft")) versionId = "DRAFT";
+        } catch (WrappedResponse wrappedResponse) {
+           return wrappedResponse.getResponse();
         }
-
         return Response.temporaryRedirect(URI.create(systemConfig.getDataverseSiteUrl() + "/dataset.xhtml?persistentId=" + persistentId + "&version=" + versionId + "&selectTab=termsTab")).build();
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -1150,8 +1150,9 @@ public class Datasets extends AbstractApiBean {
         User user = session.getUser();
         String persistentId;
         try {
-            if (!user.isAuthenticated()) user = findAuthenticatedUserOrDie();
-            getDatasetVersionOrDie(createDataverseRequest(user), versionId, findDatasetOrDie(id), uriInfo, headers);
+            if (getDatasetVersionOrDie(createDataverseRequest(user), versionId, findDatasetOrDie(id), uriInfo, headers).getTermsOfUseAndAccess().getLicense() != null){
+                return error(Status.NOT_FOUND, "This Dataset has no custom license");
+            }
             persistentId = getRequestParameter(":persistentId".substring(1));
             if (versionId.equals(":draft")) versionId = "DRAFT";
         } catch (WrappedResponse wrappedResponse) {

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -79,7 +79,6 @@ import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.ingest.IngestServiceBean;
 import edu.harvard.iq.dataverse.privateurl.PrivateUrl;
 import edu.harvard.iq.dataverse.S3PackageImporter;
-import static edu.harvard.iq.dataverse.api.AbstractApiBean.error;
 import edu.harvard.iq.dataverse.api.dto.RoleAssignmentDTO;
 import edu.harvard.iq.dataverse.batch.util.LoggingUtil;
 import edu.harvard.iq.dataverse.dataaccess.DataAccess;
@@ -112,22 +111,17 @@ import edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.URI;
 import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.EJBException;
+import javax.faces.context.FacesContext;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -160,7 +154,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
 import com.amazonaws.services.s3.model.PartETag;
-import edu.harvard.iq.dataverse.FileMetadata;
+
 import java.util.Map.Entry;
 
 @Path("datasets")
@@ -1149,6 +1143,30 @@ public class Datasets extends AbstractApiBean {
             return ex.getResponse();
         }
     }
+
+    @GET
+    @Path("{id}/versions/{versionId}/customlicense")
+    @Produces(MediaType.APPLICATION_XHTML_XML)
+    public Response getCustomTermsTab(@PathParam("id") String id, @PathParam("versionId") String versionId){
+        String persistentId = null;
+        if (id != null) {
+            if (id.equals(":persistentId")) {
+                persistentId = getRequestParameter(":persistentId".substring(1));
+                if (persistentId == null) {
+                    return error(Response.Status.BAD_REQUEST, "");
+                }
+            }
+        } else return error(Response.Status.BAD_REQUEST, "");
+
+        if (versionId == null) {
+            return error(Response.Status.BAD_REQUEST, "");
+        } else if (versionId.equals(":draft")){
+            versionId = "DRAFT";
+        }
+
+        return Response.temporaryRedirect(URI.create(systemConfig.getDataverseSiteUrl() + "/dataset.xhtml?persistentId=" + persistentId + "&version=" + versionId + "&selectTab=termsTab")).build();
+    }
+
     
     @GET
     @Path("{id}/links")

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -93,6 +93,7 @@
                     <f:viewParam name="fileTypeGroupFacet" value="#{DatasetPage.fileTypeFacet}"/>
                     <f:viewParam name="fileAccess" value="#{DatasetPage.fileAccessFacet}"/>
                     <f:viewParam name="fileTag" value="#{DatasetPage.fileTagsFacet}"/>
+                    <o:viewParam name="selectTab" value="#{DatasetPage.selectTab}"/>
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
                     <f:viewAction action="#{DatasetPage.init}" rendered="true"/>
                     <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(DatasetPage.dataset)}"/>

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -93,7 +93,7 @@
                     <f:viewParam name="fileTypeGroupFacet" value="#{DatasetPage.fileTypeFacet}"/>
                     <f:viewParam name="fileAccess" value="#{DatasetPage.fileAccessFacet}"/>
                     <f:viewParam name="fileTag" value="#{DatasetPage.fileTagsFacet}"/>
-                    <o:viewParam name="selectTab" value="#{DatasetPage.selectTab}"/>
+                    <o:viewParam name="selectTab" value="#{DatasetPage.selectTab}" default="dataFilesTab"/>
                     <f:viewAction action="#{dataverseSession.updateLocaleInViewRoot}"/>
                     <f:viewAction action="#{DatasetPage.init}" rendered="true"/>
                     <f:viewAction action="#{dataverseHeaderFragment.initBreadcrumbs(DatasetPage.dataset)}"/>


### PR DESCRIPTION
Create a dataset with a custom license

Enter the custom license url into your browser (replace brackets, example version OR draft syntax provided):
```
https://dar.dans.knaw.nl/api/datasets/:persistentId/versions/{1.0|:draft}/customlicense?persistentId={doi:10.5072/DAR/BXBIEB}
```
Should result in a redirect to dataset's termsTab