### PR TITLE
DD-549 Is field/column termsofuseandaccess.license still necessary?

### DIFF
--- a/src/main/resources/db/migration/V5.5.0.6__7440-configurable-license-list.sql
+++ b/src/main/resources/db/migration/V5.5.0.6__7440-configurable-license-list.sql
@@ -22,3 +22,4 @@ UPDATE termsofuseandaccess
 SET license_id = (SELECT license.id FROM license WHERE license.name = 'CC0')
 WHERE termsofuseandaccess.license = 'CC0' AND termsofuseandaccess.license_id IS NULL;
 
+ALTER TABLE termsofuseandaccess DROP COLUMN IF EXISTS license;


### PR DESCRIPTION
Removed termsofuseandacces.license column via flyway script

Tested by upgrading from a basebox without multi-license functionality