### PR TITLE
DD-593 integration test fixes multi license

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -863,9 +863,10 @@ public class AdminIT {
         getLicensesResponse.prettyPrint();
         body = getLicensesResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
+        long licenseId = JsonPath.from(body).getLong("data[-1].id");
         assertEquals("OK", status);
         
-        Response getLicenseByIdResponse = UtilIT.getLicenseById(1L);
+        Response getLicenseByIdResponse = UtilIT.getLicenseById(licenseId);
         getLicenseByIdResponse.prettyPrint();
         body = getLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
@@ -878,20 +879,20 @@ public class AdminIT {
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);*/
         
-        Response getLicenseErrorResponse = UtilIT.getLicenseById(10L);
+        Response getLicenseErrorResponse = UtilIT.getLicenseById(licenseId + 1L);
         getLicenseErrorResponse.prettyPrint();
         body = getLicenseErrorResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("ERROR", status);
         
         pathToJsonFile = "scripts/api/data/licenseUpdate.json";
-        Response updateLicenseByIdResponse = UtilIT.updateLicenseById(pathToJsonFile, 1L);
+        Response updateLicenseByIdResponse = UtilIT.updateLicenseById(pathToJsonFile, licenseId);
         updateLicenseByIdResponse.prettyPrint();
         body = updateLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
 
-        //TODO updateLicenseByName method does not exist yet
+        //TODO updateLicenseByName method does not exist yet or has not been merged yet
         /*pathToJsonFile = "scripts/api/data/licenseUpdate.json";
         Response updateLicenseByNameResponse = UtilIT.updateLicenseByName(pathToJsonFile, "");
         updateLicenseByNameResponse.prettyPrint();
@@ -899,26 +900,26 @@ public class AdminIT {
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);*/
         
-        Response updateLicenseErrorResponse = UtilIT.updateLicenseById(pathToJsonFile, 10L);
+        Response updateLicenseErrorResponse = UtilIT.updateLicenseById(pathToJsonFile, licenseId + 1L);
         updateLicenseErrorResponse.prettyPrint();
         body = updateLicenseErrorResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("ERROR", status);
         
-        Response deleteLicenseByIdResponse = UtilIT.deleteLicenseById(1L);
+        Response deleteLicenseByIdResponse = UtilIT.deleteLicenseById(licenseId);
         deleteLicenseByIdResponse.prettyPrint();
         body = deleteLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
 
-        //TODO deleteLicenseByName method does not exist yet
+        //TODO deleteLicenseByName method does not exist yet or has not been merged yet
         /*Response deleteLicenseByNameResponse = UtilIT.deleteLicenseByName("");
         deleteLicenseByNameResponse.prettyPrint();
         body = deleteLicenseByNameResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);*/
         
-        Response deleteLicenseErrorResponse = UtilIT.deleteLicenseById(10L);
+        Response deleteLicenseErrorResponse = UtilIT.deleteLicenseById(licenseId + 1L);
         deleteLicenseErrorResponse.prettyPrint();
         body = deleteLicenseErrorResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");

--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -870,12 +870,13 @@ public class AdminIT {
         body = getLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
-        
-        Response getLicenseByNameResponse = UtilIT.getLicenseByName("");
+
+        //TODO implement tests after these methods from PR's have been merged into multi-license
+        /*Response getLicenseByNameResponse = UtilIT.getLicenseByName("");
         getLicenseByNameResponse.prettyPrint();
         body = getLicenseByNameResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
-        assertEquals("OK", status);
+        assertEquals("OK", status);*/
         
         Response getLicenseErrorResponse = UtilIT.getLicenseById(10L);
         getLicenseErrorResponse.prettyPrint();
@@ -889,13 +890,14 @@ public class AdminIT {
         body = updateLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
-        
-        pathToJsonFile = "scripts/api/data/licenseUpdate.json";
+
+        //TODO updateLicenseByName method does not exist yet
+        /*pathToJsonFile = "scripts/api/data/licenseUpdate.json";
         Response updateLicenseByNameResponse = UtilIT.updateLicenseByName(pathToJsonFile, "");
         updateLicenseByNameResponse.prettyPrint();
         body = updateLicenseByNameResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
-        assertEquals("OK", status);
+        assertEquals("OK", status);*/
         
         Response updateLicenseErrorResponse = UtilIT.updateLicenseById(pathToJsonFile, 10L);
         updateLicenseErrorResponse.prettyPrint();
@@ -908,12 +910,13 @@ public class AdminIT {
         body = deleteLicenseByIdResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
         assertEquals("OK", status);
-        
-        Response deleteLicenseByNameResponse = UtilIT.deleteLicenseByName("");
+
+        //TODO deleteLicenseByName method does not exist yet
+        /*Response deleteLicenseByNameResponse = UtilIT.deleteLicenseByName("");
         deleteLicenseByNameResponse.prettyPrint();
         body = deleteLicenseByNameResponse.getBody().asString();
         status = JsonPath.from(body).getString("status");
-        assertEquals("OK", status);
+        assertEquals("OK", status);*/
         
         Response deleteLicenseErrorResponse = UtilIT.deleteLicenseById(10L);
         deleteLicenseErrorResponse.prettyPrint();

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2679,17 +2679,12 @@ public class UtilIT {
     static Response updateLicenseById(String pathToJsonFile, Long id) {
         String jsonIn = getDatasetJson(pathToJsonFile);
 
-        RequestSpecification request = RestAssured.given();
-        request.header("Content-Type", "application/json");
-        request.body(jsonIn);
-        return request.put("/api/admin/licenses/{id}", id);
-
-        /*Response updateLicenseResponse = given()
+        Response updateLicenseResponse = given()
                 .request()
                 .body(jsonIn)
                 .contentType("application/json")
                 .put("/api/admin/licenses/{id}", id);
-        return updateLicenseResponse;*/
+        return updateLicenseResponse;
 
 
     }

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -1,5 +1,6 @@
 package edu.harvard.iq.dataverse.api;
 
+import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.response.Response;
@@ -9,6 +10,8 @@ import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -35,6 +38,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+
+import static com.jayway.restassured.RestAssured.put;
 import static com.jayway.restassured.path.xml.XmlPath.from;
 import static com.jayway.restassured.RestAssured.given;
 import edu.harvard.iq.dataverse.util.StringUtil;
@@ -2660,7 +2665,7 @@ public class UtilIT {
     static Response getLicenseById(Long id) {
 
         Response getLicenseResponse = given()
-                .get("/api/admin/licenses/id/"+id.toString());
+                .get("/api/admin/licenses/"+id.toString());
         return getLicenseResponse;
     }
 
@@ -2674,11 +2679,19 @@ public class UtilIT {
     static Response updateLicenseById(String pathToJsonFile, Long id) {
         String jsonIn = getDatasetJson(pathToJsonFile);
 
-        Response updateLicenseResponse = given()
+        RequestSpecification request = RestAssured.given();
+        request.header("Content-Type", "application/json");
+        request.body(jsonIn);
+        return request.put("/api/admin/licenses/{id}", id);
+
+        /*Response updateLicenseResponse = given()
+                .request()
                 .body(jsonIn)
                 .contentType("application/json")
-                .put("/api/admin/licenses/id/"+id.toString());
-        return updateLicenseResponse;
+                .put("/api/admin/licenses/{id}", id);
+        return updateLicenseResponse;*/
+
+
     }
 
     static Response updateLicenseByName(String pathToJsonFile, String name) {
@@ -2694,7 +2707,7 @@ public class UtilIT {
     static Response deleteLicenseById(Long id) {
 
         Response deleteLicenseResponse = given()
-                .delete("/api/admin/licenses/id/"+id.toString());
+                .delete("/api/admin/licenses/"+id.toString());
         return deleteLicenseResponse;
     }
 


### PR DESCRIPTION
Running an Integration Test on our dd-dtap env:
_[source](https://guides.dataverse.org/en/latest/developers/testing.html) (Getting Set Up to Run REST Assured Tests)_

Had a hard time installing the right Maven version on Centos 8 so i forwarded port 8080 to my localhost instead (VirtualBox -> Settings -> Network(advanced) -> Port Forwarding):
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/56864998/132523360-88640892-961a-412e-873c-475f7cd1d911.png">


```
# make sure there are no :BlockedApiEndpoints for this to work, I deleted both :BlockedApiEndpoints and :BlockedApiPolicy from the database directly

# mysteriously needed according to docs
curl -X PUT -d 'burrito' http://localhost:8080/api/admin/settings/BuiltinUsers.KEY

curl -s -X POST -H "Content-type:application/json" -d "{\"assignee\": \":authenticated-users\",\"role\": \"fullContributor\"}" "http://localhost:8080/api/dataverses/root/assignments?key=$(apikey)"

# change directory to local dataverse to run test
mvn test -Dtest=AdminIT -Ddataverse.test.baseurl='http://localhost:8080'

# run the full IT suite:
mvn test -Dtest=DataversesIT,DatasetsIT,SwordIT,AdminIT,BuiltinUsersIT,UsersIT,UtilIT,ConfirmEmailIT,FileMetadataIT,FilesIT,SearchIT,InReviewWorkflowIT,HarvestingServerIT,MoveIT,MakeDataCountApiIT,FileTypeDetectionIT,EditDDIIT,ExternalToolsIT,AccessIT,DuplicateFilesIT,DownloadFilesIT,LinkIT,DeleteUsersIT,DeactivateUsersIT,AuxiliaryFilesIT -Ddataverse.test.baseurl='http://localhost:8080'
```
