### PR TITLE
DD-561 Updated SwordServiceBean to support multi-license

### DIFF
--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -21,20 +21,20 @@ jobs:
                 #        jdk: '16'
         runs-on: ${{ matrix.os }}
         steps:
-#          - uses: actions/checkout@v2
-#          - name: Set up JDK ${{ matrix.jdk }}
-#            uses: actions/setup-java@v2
-#            with:
-#                java-version: ${{ matrix.jdk }}
-#                distribution: 'adopt'
-#          - name: Cache Maven packages
-#            uses: actions/cache@v2
-#            with:
-#                path: ~/.m2
-#                key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-#                restore-keys: ${{ runner.os }}-m2
-#          - name: Build with Maven
-#            run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
+          - uses: actions/checkout@v2
+          - name: Set up JDK ${{ matrix.jdk }}
+            uses: actions/setup-java@v2
+            with:
+                java-version: ${{ matrix.jdk }}
+                distribution: 'adopt'
+          - name: Cache Maven packages
+            uses: actions/cache@v2
+            with:
+                path: ~/.m2
+                key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                restore-keys: ${{ runner.os }}-m2
+          - name: Build with Maven
+            run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
           - name: Maven Code Coverage
             env:
                 CI_NAME: github

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -35,14 +35,8 @@ jobs:
                 restore-keys: ${{ runner.os }}-m2
           - name: Build with Maven
             run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
-
-          - uses: codecov/codecov-action@v1
-            with:
-                file: ./**/target/site/jacoco/jacoco.xml
-                name: codecov
-
-#          - name: Maven Code Coverage
-#            env:
-#                CI_NAME: github
-#                COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
-#            run: mvn -e -X -V -B jacoco:report coveralls:report -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }} -DisDebugEnabled=true
+          - name: Maven Code Coverage
+            env:
+                CI_NAME: github
+                COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
+            run: mvn -e -X -V -B coveralls:report -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }}

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -21,20 +21,20 @@ jobs:
                 #        jdk: '16'
         runs-on: ${{ matrix.os }}
         steps:
-          - uses: actions/checkout@v2
-          - name: Set up JDK ${{ matrix.jdk }}
-            uses: actions/setup-java@v2
-            with:
-                java-version: ${{ matrix.jdk }}
-                distribution: 'adopt'
-          - name: Cache Maven packages
-            uses: actions/cache@v2
-            with:
-                path: ~/.m2
-                key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-                restore-keys: ${{ runner.os }}-m2
-          - name: Build with Maven
-            run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
+#          - uses: actions/checkout@v2
+#          - name: Set up JDK ${{ matrix.jdk }}
+#            uses: actions/setup-java@v2
+#            with:
+#                java-version: ${{ matrix.jdk }}
+#                distribution: 'adopt'
+#          - name: Cache Maven packages
+#            uses: actions/cache@v2
+#            with:
+#                path: ~/.m2
+#                key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+#                restore-keys: ${{ runner.os }}-m2
+#          - name: Build with Maven
+#            run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
           - name: Maven Code Coverage
             env:
                 CI_NAME: github

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -39,4 +39,4 @@ jobs:
             env:
                 CI_NAME: github
                 COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
-            run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }}
+            run: mvn -eX -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }}

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -39,4 +39,4 @@ jobs:
             env:
                 CI_NAME: github
                 COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
-            run: mvn -e -X -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }}
+            run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }} -DisDebugEnabled=true

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -39,4 +39,4 @@ jobs:
             env:
                 CI_NAME: github
                 COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
-            run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }} -DisDebugEnabled=true
+            run: mvn -e -X -V -B jacoco:report coveralls:report -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }} -DisDebugEnabled=true

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -39,4 +39,4 @@ jobs:
             env:
                 CI_NAME: github
                 COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
-            run: mvn -eX -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }}
+            run: mvn -e -X -V -B jacoco:report coveralls:report -DrepoToken=${COVERALLS_SECRET} -DpullRequest=${{ github.event.number }}

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -35,8 +35,14 @@ jobs:
                 restore-keys: ${{ runner.os }}-m2
           - name: Build with Maven
             run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
-          - name: Maven Code Coverage
-            env:
-                CI_NAME: github
-                COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
-            run: mvn -e -X -V -B jacoco:report coveralls:report -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }} -DisDebugEnabled=true
+
+          - name: Coveralls
+            uses: coverallsapp/github-action@master
+            with:
+                github-token: ${{ secrets.github_token }}
+
+#          - name: Maven Code Coverage
+#            env:
+#                CI_NAME: github
+#                COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
+#            run: mvn -e -X -V -B jacoco:report coveralls:report -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }} -DisDebugEnabled=true

--- a/.github/workflows/maven_unit_test.yml
+++ b/.github/workflows/maven_unit_test.yml
@@ -36,10 +36,10 @@ jobs:
           - name: Build with Maven
             run: mvn -DcompilerArgument=-Xlint:unchecked -P all-unit-tests clean test
 
-          - name: Coveralls
-            uses: coverallsapp/github-action@master
+          - uses: codecov/codecov-action@v1
             with:
-                github-token: ${{ secrets.github_token }}
+                file: ./**/target/site/jacoco/jacoco.xml
+                name: codecov
 
 #          - name: Maven Code Coverage
 #            env:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently in the multi-license branch `edu.harvard.iq.dataverse.api.datadeposit.SwordServiceBean` still contains references to CC0. Since CC0 is no longer necessarily the default, or even guaranteed to be an option, the rules should be modified to use the default license instead of CC0.

**Which issue(s) this PR closes**:

Closes #[DD-561](https://drivenbydata.atlassian.net/browse/DD-561)

**Special notes for your reviewer**:
Making a new PR because previous one has a Maven compilation error that does not happen on my development machine. 

**Suggestions on how to test this**:

Tested this with the Sword interface using the example xml from the Dataverse documentation:
Create a Dataset with an Atom entry:
[XML](https://guides.dataverse.org/en/latest/api/sword.html#id11)

make sure `./deploy-module configure-licenses` has been run succesfully

Created a dataset with:
```
curl -u $(apikey): --data-binary "@/vagrant/shared/swordservicetest.xml" -H "Content-Type: application/atom+xml" 'http://localhost:8080/dvn/api/data-deposit/v1.1/swordv2/collection/dataverse/root'

Test 1
<dcterms:license>Custom License</dcterms:license>
<dcterms:rights>Downloader will not use the Materials in any way prohibited by applicable laws.</dcterms:rights>

Test 2 (results in error like it should)
<dcterms:license>CC0-1.0</dcterms:license>
<dcterms:rights>Downloader will not use the Materials in any way prohibited by applicable laws.</dcterms:rights>

Test 3
<dcterms:license>CC0-1.0</dcterms:license>

Test 4 (results in error)
<dcterms:license></dcterms:license>

Test 5 results in the default license
no dcterms specified

```
