### PR TITLE
Also need to handle new install where license column doesn't exist

### DIFF
--- a/src/main/resources/db/migration/V5.8.0.1__7440-configurable-license-list.sql
+++ b/src/main/resources/db/migration/V5.8.0.1__7440-configurable-license-list.sql
@@ -15,10 +15,13 @@ BEGIN
     WHEN unique_violation THEN RAISE NOTICE 'CC0 has already been added to the license table';
   END;
 
+  BEGIN
+      UPDATE termsofuseandaccess
+        SET license_id = (SELECT license.id FROM license WHERE license.name = 'CC0')
+        WHERE termsofuseandaccess.license = 'CC0' AND termsofuseandaccess.license_id IS NULL;
+  EXCEPTION
+    WHEN undefined_column THEN RAISE NOTICE 'license is not in table - new instance';
+  END;
+
 END $$;
-
-UPDATE termsofuseandaccess
-SET license_id = (SELECT license.id FROM license WHERE license.name = 'CC0')
-WHERE termsofuseandaccess.license = 'CC0' AND termsofuseandaccess.license_id IS NULL;
-
 ALTER TABLE termsofuseandaccess DROP COLUMN IF EXISTS license;


### PR DESCRIPTION
A new install fails running the existing flyway script because, with a new install, a termsofuseandaccess.license column doesn't exist. This PR just catches that exception to avoid the failure. (This part of the script is trying to handle existing CC0 values which don't exist with a new install, so skipping this step is fine in that case.)
