### PR TITLE
remove obsolete tests

### DIFF
--- a/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/AdminIT.java
@@ -878,19 +878,6 @@ public class AdminIT {
         status = JsonPath.from(body).getString("status");
         assertEquals("ERROR", status);
         
-        pathToJsonFile = "src/test/resources/json/licenseUpdate.json";
-        Response updateLicenseByIdResponse = UtilIT.updateLicenseById(pathToJsonFile, licenseId);
-        updateLicenseByIdResponse.prettyPrint();
-        body = updateLicenseByIdResponse.getBody().asString();
-        status = JsonPath.from(body).getString("status");
-        assertEquals("OK", status);
-        
-        Response updateLicenseErrorResponse = UtilIT.updateLicenseById(pathToJsonFile, licenseId + 1L);
-        updateLicenseErrorResponse.prettyPrint();
-        body = updateLicenseErrorResponse.getBody().asString();
-        status = JsonPath.from(body).getString("status");
-        assertEquals("ERROR", status);
-        
         Response deleteLicenseByIdResponse = UtilIT.deleteLicenseById(licenseId);
         deleteLicenseByIdResponse.prettyPrint();
         body = deleteLicenseByIdResponse.getBody().asString();

--- a/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/UtilIT.java
@@ -2736,29 +2736,6 @@ public class UtilIT {
         return getLicenseResponse;
     }
 
-    static Response updateLicenseById(String pathToJsonFile, Long id) {
-        String jsonIn = getDatasetJson(pathToJsonFile);
-
-        Response updateLicenseResponse = given()
-                .request()
-                .body(jsonIn)
-                .contentType("application/json")
-                .put("/api/admin/licenses/{id}", id);
-        return updateLicenseResponse;
-
-
-    }
-
-    static Response updateLicenseByName(String pathToJsonFile, String name) {
-        String jsonIn = getDatasetJson(pathToJsonFile);
-
-        Response updateLicenseResponse = given()
-                .body(jsonIn)
-                .contentType("application/json")
-                .put("/api/admin/licenses/name/"+name);
-        return updateLicenseResponse;
-    }
-
     static Response deleteLicenseById(Long id) {
 
         Response deleteLicenseResponse = given()

--- a/src/test/resources/json/licenseUpdate.json
+++ b/src/test/resources/json/licenseUpdate.json
@@ -1,7 +1,0 @@
-{
-  "name": "CC-BY-4.0",
-  "uri": "http://creativecommons.org/licenses/by/4.0",
-  "shortDescription": "Creative Commons Attribution 4.0 International License.",
-  "iconUrl": "https://i.creativecommons.org/l/by/4.0/88x31.png",
-  "active": true
-}


### PR DESCRIPTION
editing existing licenses is no longer allowed, so tests not needed
(were failing with
{
  "status":"ERROR",
  "code":405,
  "message":"API endpoint does not support this method. Consult our API
guide at http://guides.dataverse.org.",
  "requestUrl":"http://localhost:8080/api/v1/admin/licenses/4",
  "requestMethod":"PUT"
}

