### PR TITLE
Exlude mime4j depedencies via sword2, as they win out over the correct versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
             <groupId>io.gdcc</groupId>
             <artifactId>sword2-server</artifactId>
             <version>1.2.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.james</groupId>
+                    <artifactId>apache-mime4j-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Dependency to use sword2-server in our codebase -->
         <dependency>


### PR DESCRIPTION

**What this PR does / why we need it**:

Previous PATCH-2 on  v5.11.1-DANS-DataStation. 
>Resolves: IQSS#9077
 sword2-server library overrides tika's apache-mime4j-core dependency with older version #9077 

You can compare that patch 2 with patch 1: 
https://github.com/DANS-KNAW/dataverse/compare/v5.11.1-DANS-DataStation-PATCH-1...v5.11.1-DANS-DataStation-PATCH-2

Difference can be seen in pom.xml (line 90)
```
            <groupId>io.gdcc</groupId>
            <artifactId>sword2-server</artifactId>
            <version>1.2.1</version>
            <exclusions>
                <exclusion>
                    <groupId>org.apache.james</groupId>
                    <artifactId>apache-mime4j-core</artifactId>
                </exclusion>
            </exclusions>
```

