### PR TITLE
FD-7423. Fix upload zip with backslashes

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -984,7 +984,7 @@ public class FileUtil implements java.io.Serializable  {
                         ZipEntry entry = entries.nextElement();
                         logger.fine("inside first zip pass; this entry: "+entry.getName());
                         if (!entry.isDirectory()) {
-                            String shortName = entry.getName().replaceFirst("^.*[\\/]", "");
+                            String shortName = entry.getName().replaceFirst("^.*[\\\\/]", "");
                             // ... and, finally, check if it's a "fake" file - a zip archive entry
                             // created for a MacOS X filesystem element: (these
                             // start with "._") 

--- a/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java
@@ -1055,7 +1055,7 @@ public class FileUtil implements java.io.Serializable  {
 
                             if (fileEntryName != null && !fileEntryName.equals("")) {
 
-                                String shortName = fileEntryName.replaceFirst("^.*[\\/]", "");
+                                String shortName = fileEntryName.replaceFirst("^.*[\\\\/]", "");
 
                                 // Check if it's a "fake" file - a zip archive entry
                                 // created for a MacOS X filesystem element: (these


### PR DESCRIPTION
**What this PR does / why we need it**:

Reapplies what was in PATCH-4 on v5.11.1. 

Compare patch 4 with patch 3 to see what was added
https://github.com/DANS-KNAW/dataverse/compare/v5.11.1-DANS-DataStation-PATCH-3...v5.11.1-DANS-DataStation-PATCH-4

In `src/main/java/edu/harvard/iq/dataverse/util/FileUtil.java`
Line 956
changed 
```
String shortName = fileEntryName.replaceFirst("^.*[\\/]", "");
```
to
```
String shortName = fileEntryName.replaceFirst("^.*[\\\\/]", "");
```

This is a bit more involved with version 5.14, because IQSS changes nearby code. 

For this patch that line is changed; now line 1058. To be consistent also another line (987) is change with the same replace function call. 
```
String shortName = entry.getName().replaceFirst("^.*[\\\\/]", "");
```

Looking at the code it needs more attention, but better do that in a PR at IQSS. 

**How to test this**

1. Start a vagrant box with a datastation, like `dev_archaeology`. 
2. Upgrade to v5.14 using the new patch from dd-dtap: 
    `deploy.py --playbook provisioning/patches/upgrade-dataverse/to-5.14.yml dev_archaeology`
    This will give the IQSS version of v5.14
3. Then build an deploy the new DANS-DataStation war for PATCH-2. 
    For instance `deploy.py --dataverse-war shared-code/dataverse/target/dataverse-5.14`.

**Related PR's**
https://github.com/DANS-KNAW/dd-dtap/pull/351

