### PR TITLE
Implement the Shibboleth login changes that are needed for DataverseNL

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
+++ b/src/main/java/edu/harvard/iq/dataverse/SettingsWrapper.java
@@ -83,7 +83,10 @@ public class SettingsWrapper implements java.io.Serializable {
     private String appVersionWithBuildNumber = null; 
     
     private Boolean shibPassiveLoginEnabled = null; 
-    
+
+    // DANS Shib login without discofeed
+    private Boolean shibIdpSelectEnabled = null;
+
     private String footerCopyrightAndYear = null; 
     
     //External Vocabulary support
@@ -667,7 +670,14 @@ public class SettingsWrapper implements java.io.Serializable {
         }
         return shibPassiveLoginEnabled;
     }
-    
+    // DANS Shib login without discofeed
+    public boolean isShibIdpSelectEnabled() {
+        if (shibIdpSelectEnabled == null) {
+            shibIdpSelectEnabled = systemConfig.isShibIdpSelectEnabled();
+        }
+        return shibIdpSelectEnabled;
+    }
+
     // Caching this result may not be saving much, *currently* (since the value is 
     // stored in the bundle). -- L.A. 5.8
     public String getFooterCopyrightAndYear() {

--- a/src/main/java/edu/harvard/iq/dataverse/Shib.java
+++ b/src/main/java/edu/harvard/iq/dataverse/Shib.java
@@ -19,6 +19,7 @@ import edu.harvard.iq.dataverse.validation.EMailValidator;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -416,6 +417,13 @@ public class Shib implements java.io.Serializable {
         Object attribute = request.getAttribute(key);
         if (attribute != null) {
             String attributeValue = attribute.toString();
+            if(systemConfig.isShibAttributeCharacterSetConversionEnabled()) {
+                try {
+                    attributeValue = new String(attributeValue.getBytes("ISO-8859-1"), "UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    logger.warning("Character conversion failed for Shib attribute (key, value) = (" + key + ", " + attributeValue + ") ; ignoring it");
+                }
+            }
             String trimmedValue = attributeValue.trim();
             if (!trimmedValue.isEmpty()) {
                 logger.fine("The SAML assertion for \"" + key + "\" (optional) was \"" + attributeValue + "\" and was trimmed to \"" + trimmedValue + "\".");

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -440,6 +440,10 @@ public class SettingsServiceBean {
          */
         ShibAffiliationSeparator,
         /**
+         * Get list of providers from discofeed and provide selection for login within Dataverse, default true
+         */
+        ShibIdpSelectEnabled,
+        /**
          * Validate physical files for all the datafiles in the dataset when publishing
          */
         FileValidationOnPublishEnabled,

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -614,6 +614,11 @@ public class SystemConfig {
         boolean defaultResponse = true;
         return settingsService.isTrueForKey(SettingsServiceBean.Key.ShibAttributeCharacterSetConversionEnabled, defaultResponse);
     }
+    // DANS Shib login without discofeed
+    public boolean isShibIdpSelectEnabled() {
+        boolean defaultResponse = true;
+        return settingsService.isTrueForKey(SettingsServiceBean.Key.ShibIdpSelectEnabled, defaultResponse);
+    }
 
     /**
      * getPVDictionaries

--- a/src/main/webapp/loginpage.xhtml
+++ b/src/main/webapp/loginpage.xhtml
@@ -120,8 +120,34 @@
                                         </h:outputFormat>
                                     </p>
                                 </h:form>
-
+                                <!-- DANS Shib login without discofeed; idpselect is not done here! - Start -->
+                                <div jsf:rendered="#{!settingsWrapper.shibIdpSelectEnabled}">
                                 <div class="form-horizontal">
+                                    <div class="form-group text-left">
+                                        <div class="col-sm-12" >
+                                            <form action="/Shibboleth.sso/Login" method="POST" autocomplete="OFF" class="form-inline">
+                                                <input type="hidden" name="SAMLDS" value="1"/>
+                                                <input name="target" value="#{systemConfig.dataverseSiteUrl}/shib.xhtml" type="hidden"/>
+                                                <!-- <div class="IdPSelectTextDiv help-block"></div> -->
+                                                <div class="form-group">
+                                                    <div class="col-sm-9 button-block">
+                                                        <button id="login" name="login" class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only btn btn-default" onclick="return true;" type="submit" role="button" aria-disabled="false">
+                                                            <!-- <span class="ui-button-text ui-c text-nowrap">#{bundle['login.institution']}</span> -->
+                                                            <!-- #{bundle['login.institution']} used to be 'Institutional Login' -->
+                                                            <span class="ui-button-text ui-c text-nowrap">
+                                                                <h:outputText value="#{LoginPage.getLoginButtonText()}"/>
+                                                            </span>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+                                </div>
+                                <!-- DANS Shib login without discofeed - End -->
+                                <div jsf:rendered="#{settingsWrapper.shibIdpSelectEnabled}">
+                                <div class="form-horizontal" >
                                     <div class="form-group text-left">
                                         <label class="col-sm-4 control-label">
                                             #{bundle['auth.providers.title.shib']}
@@ -161,6 +187,7 @@
                                 <script src="/resources/js/shib/idpselect_config.js"></script>
                                 <script src="/resources/js/shib/idpselect.js"></script>
                                 <script src="/resources/js/shib/idpselect_style.js"></script>
+                            </div>
                             </div>
 
                             <!--ONLY RENDER BUTTON FOR OAUTH PROVIDERS (ORCID, Google, GitHub)-->


### PR DESCRIPTION
**What this PR does / why we need it**:

The Shib login page wants to display a dropdown list of Idp's it gets from the Shibboleth 'discofeed'. 
For the DataverseNL server we have only one Idp (SURF) which in turn provides its own selection list. Also the current server setup does not have a working 'discofeed' so this results in an error not allowing to login. 

Instead of showing the Idp list (idpselect in the Dataverse code) we show a button that takes you to SURF (via a POST to shib.xhtml). 
To make this more acceptable to others and possibly into a PR at IQSS this has been made configurable via the setting ':ShibIdpSelectEnabled', disabling can be done via the following curl command:
```
curl -X PUT -d false http://localhost:8080/api/admin/settings/:ShibIdpSelectEnabled
```

Also added a FIX for diacritic character conversion problems that was detected on DataverseNL and others. There is an issue and PR at IQSS, but that has not been merged. Adding it here and testing it would help getting it merged next time. 
Our Jira issue: 
https://drivenbydata.atlassian.net/browse/DDN-686
Issue at IQSS
https://github.com/IQSS/dataverse/issues/8573
PR at IQSS:
https://github.com/IQSS/dataverse/pull/9461

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
When disabled the login with Shib looks like this:

![Screenshot from DVNL-Refactored](https://github.com/DANS-KNAW/dataverse/assets/2151103/eeb02e7a-5381-4947-973c-0f6e5e236df3)

**Is there a release notes update needed for this change?**:

**Additional documentation**:
