### PR TITLE
DD-1058 Use support email in the system email message 'closing' text

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/MailServiceBean.java
@@ -42,6 +42,7 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
+import edu.harvard.iq.dataverse.settings.JvmSettings;
 import edu.harvard.iq.dataverse.validation.EMailValidator;
 import org.apache.commons.lang3.StringUtils;
 
@@ -92,11 +93,12 @@ public class MailServiceBean implements java.io.Serializable {
     public boolean sendSystemEmail(String to, String subject, String messageText, boolean isHtmlContent) {
 
         boolean sent = false;
-        InternetAddress systemAddress = getSystemAddress(); 
+        InternetAddress systemAddress = getSystemAddress();
+        InternetAddress supportAddress = getSupportAddress();
 
         String body = messageText
-                + (isHtmlContent ? BundleUtil.getStringFromBundle("notification.email.closing.html", Arrays.asList(BrandingUtil.getSupportTeamEmailAddress(systemAddress), BrandingUtil.getSupportTeamName(systemAddress)))
-                        : BundleUtil.getStringFromBundle("notification.email.closing", Arrays.asList(BrandingUtil.getSupportTeamEmailAddress(systemAddress), BrandingUtil.getSupportTeamName(systemAddress))));
+                + (isHtmlContent ? BundleUtil.getStringFromBundle("notification.email.closing.html", Arrays.asList(BrandingUtil.getSupportTeamEmailAddress(supportAddress), BrandingUtil.getSupportTeamName(supportAddress)))
+                        : BundleUtil.getStringFromBundle("notification.email.closing", Arrays.asList(BrandingUtil.getSupportTeamEmailAddress(supportAddress), BrandingUtil.getSupportTeamName(supportAddress))));
 
         logger.fine("Sending email to " + to + ". Subject: <<<" + subject + ">>>. Body: " + body);
         try {
@@ -144,6 +146,13 @@ public class MailServiceBean implements java.io.Serializable {
     public InternetAddress getSystemAddress() {
        String systemEmail = settingsService.getValueForKey(Key.SystemEmail);
        return MailUtil.parseSystemAddress(systemEmail);
+    }
+
+    public InternetAddress getSupportAddress() {
+        String supportEmail = JvmSettings.SUPPORT_EMAIL
+            .lookupOptional()
+            .orElse(settingsService.getValueForKey(SettingsServiceBean.Key.SystemEmail));
+        return MailUtil.parseSystemAddress(supportEmail);
     }
 
     //@Resource(name="mail/notifyMailSession")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a problem =with the 'system emails', the end of thos emails refer to a contact email, but instaed of using that ione, the system email address is being used. 

**Which issue(s) this PR closes**:
Jira issue: https://drivenbydata.atlassian.net/browse/DD-1058

**Special notes for your reviewer**:

**Suggestions on how to test this**:

- Checkout and build this PR for instance in the `dd-dtap/shared-code` directory.
- Start the archaeoloy base box; `start-preprovisioned-box.py -s dev_archaeology dev_vocabs`.
- Upgrade to 5.14; `deploy.py --playbook provisioning/patches/upgrade-dataverse/to-5.14.yml dev_archaeology
`. 
- Set the jvm option; `vagrant ssh dev_archaeology` and then `/usr/local/payara5/glassfish/bin/asadmin -Dcreate-jvm-options dataverse.mail.support-email=arc@datastations.nl ` and restart payara; `sudo systemctl restart payara`.. 
- In `dd-dtap`, deploy the'fixed' war file; `deploy.py --dataverse-war shared-code/dataverse/target/dataverse-5.14 dev_archaeology`.
- Browse to the password reset page; `https://dev.archaeology.datastations.nl/passwordreset.xhtml` and request a reset for a test user account, for instance `testing@dans.knaw.nl`. 
- On the vagrant box, check if the mail is sent with `curl http://0.0.0.0:1080/messages | jq`. 
```
[
  {
    "id": 2,
    "sender": "<noreply@datastations.nl>",
    "recipients": [
      "<testing@dans.knaw.nl>"
    ],
    "subject": "Dataverse Password Reset Requested",
    "size": "852",
    "created_at": "2023-09-05T11:49:53+00:00"
  }
]
```
- Use the id to read the mail text; `curl http://0.0.0.0:1080/messages/2.plain` if the id = 2. 

```
Hi Testing  Testing,

Someone, hopefully you, requested a password reset for testing.

Please click the link below to reset your Dataverse account password:

 https://dev.archaeology.datastations.nl/passwordreset.xhtml?token=8320bc66-7045-4339-ab0f-7ac6268ec7d8 

 The link above will only work for the next 60 minutes.

 Please contact us if you did not request this password reset or need further help.

You may contact us for support at arc@datastations.nl.

Thank you,
DANS Data Station Archaeology (dev) Support
```

Important to check is that the 'sender' is still the system email; `noreply@datastations.nl`, but the mail text should give that support email address (`arc@datastations.nl`) to contact us!

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
