### PR TITLE
DD-1359: no validation on template change

### DIFF
--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -728,6 +728,7 @@
                                 <p:commandButton value="#{bundle['file.dataFilesTab.button.direct']}" id="updateTemplate"
                                                  style="display:none"
                                                  update=":datasetForm,accessPopup"
+                                                 immediate="true"
                                                  action="#{DatasetPage.handleChangeButton}" oncomplete="javascript:bind_bsui_components();">
                                 </p:commandButton>
                             </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow to select another template without having to select "_Personal Data In Dataset?_" which gets overwritten by the template

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

https://github.com/IQSS/dataverse/issues/10119 Premature validation of dataset metadata (single value drop down) prevents template selection

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:

