### PR TITLE
DD-1359: template change is blocked by premature validation

### DIFF
--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -247,7 +247,7 @@
                                                     <div class="form-group dataset-field-values">
                                                         <div class="form-col-container col-sm-9 edit-field">
                                                             <p:selectOneMenu value="#{dsf.singleControlledVocabularyValue}" converter="controlledVocabularyValueConverter" style="width: auto !important; max-width:100%; min-width:200px;" styleClass="form-control primitive"
-                                                                             id="unique1" required="#{dsf.required and datasetPage}" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
+                                                                             id="unique1" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
                                                                 <f:selectItem itemLabel="#{bundle.select}" itemValue="" noSelectionOption="true"/>
                                                                 <f:selectItems value="#{dsf.datasetFieldType.controlledVocabularyValues}" var="cvv" itemLabel="#{cvv.getLocaleStrValue(mdLangCode)}" itemValue="#{cvv}"/>
                                                             </p:selectOneMenu>


### PR DESCRIPTION
…mandatory

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

Could not find other metadata fields that could suffer from undesired effects by this change.

**Suggestions on how to test this**:

See DANS Jira issue. 

Tested with branches `v5.14-DANS-DataStation-PATCH-4`, `dans-develop` as well as a manual change on `dev_archaeology-2023-10-23.box`

See also https://github.com/IQSS/dataverse/issues/10119
It uses a customized metadatablock “Journal metadata“ with a required “type of article“  
as equivalent for our "Personal Data In Dataset?"

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
