### PR TITLE
Re-apply PATCH-1 to v6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
             <groupId>io.gdcc</groupId>
             <artifactId>sword2-server</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.james</groupId>
+                    <artifactId>apache-mime4j-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Dependency to use sword2-server in our codebase -->
         <dependency>


### PR DESCRIPTION
Exlude mime4j depedencies via sword2, as they win out over the correct versions
