### PR TITLE
Re-apply PATCH-5 to v6.0

### DIFF
--- a/src/main/webapp/metadataFragment.xhtml
+++ b/src/main/webapp/metadataFragment.xhtml
@@ -285,7 +285,7 @@
                                                     <div class="form-group dataset-field-values">
                                                         <div class="form-col-container col-sm-9 edit-field">
                                                             <p:selectOneMenu value="#{dsf.singleControlledVocabularyValue}" converter="controlledVocabularyValueConverter" style="width: auto !important; max-width:100%; min-width:200px;" styleClass="form-control primitive"
-                                                                             id="unique1" required="#{dsf.required and datasetPage}" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
+                                                                             id="unique1" rendered="#{!dsf.datasetFieldType.allowMultiples}" filter="#{(dsf.datasetFieldType.controlledVocabularyValues.size() lt 10) ? 'false':'true'}" filterMatchMode="contains">
                                                                 <f:selectItem itemLabel="#{bundle.select}" itemValue="" noSelectionOption="true"/>
                                                                 <f:selectItems value="#{dsf.datasetFieldType.controlledVocabularyValues}" var="cvv" itemLabel="#{cvv.getLocaleStrValue(mdLangCode)}" itemValue="#{cvv}"/>
                                                             </p:selectOneMenu>


### PR DESCRIPTION
metadata parameters in tsv/database are enough to make SelectOneMenu mandatory

**What this PR does / why we need it**:

This is needed to get all DANS patches in the Dataverse v6.0 war that needs to be deployed on the new Payara6 platform

**Suggestions on how to test this**:
Start with a fresh basebox
`start-preprovisioned-box.py -s`
Then apply the upgrade (from a draft PR in dd-dtap https://github.com/DANS-KNAW/dd-dtap/pull/375)
`deploy.py --playbook provisioning/patches/upgrade-dataverse-platform/to-6.yml dev_archaeology`
Note that the Soklr upgrade is not needed for this test. 
Then build and deploy the war file from this PR fro PATCH-5
`deploy.py --dataverse-war shared-code/dataverse/target/dataverse-6.0.war dev_archaeology`



