### PR TITLE
DD-1467: NullPointerException for update single compound field

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -97,6 +97,7 @@ import edu.harvard.iq.dataverse.util.SignpostingResources;
 import edu.harvard.iq.dataverse.util.json.JsonUtil;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 
+import static edu.harvard.iq.dataverse.util.StringUtil.isEmpty;
 import static edu.harvard.iq.dataverse.util.json.JsonPrinter.*;
 import static edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder.jsonObjectBuilder;
 import edu.harvard.iq.dataverse.util.json.NullSafeJsonBuilder;
@@ -1114,7 +1115,7 @@ public class Datasets extends AbstractApiBean {
             if (dsf.getDatasetFieldType().isAllowMultiples() && dsf.getControlledVocabularyValues().isEmpty()
                     && dsf.getDatasetFieldCompoundValues().isEmpty() && dsf.getDatasetFieldValues().isEmpty()) {
                 error.append("Empty multiple value for field: ").append(dsf.getDatasetFieldType().getDisplayName()).append(" ");
-            } else if (!dsf.getDatasetFieldType().isAllowMultiples() && dsf.getSingleValue().getValue().isEmpty()) {
+            } else if (!dsf.getDatasetFieldType().isAllowMultiples() && isEmpty(dsf.getSingleValue().getValue())) {
                 error.append("Empty value for field: ").append(dsf.getDatasetFieldType().getDisplayName()).append(" ");
             }
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

Turn a 500-internal-server error due to a null pointer exception into a 400-bad-request due to a

    Semantic error parsing dataset update Json: Empty value for field: Notes

as discovered by the manual not-dry test variant for https://github.com/DANS-KNAW/dans-datastation-tools/pull/51/commits/1101aa92ef3350847bf1163a4a9f542ceaeb851f

See also
* https://github.com/IQSS/dataverse/issues/7605
* https://github.com/IQSS/dataverse/issues/8860

**Which issue(s) this PR closes**:

Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
