### PR TITLE
Back-ported syntax error fix in installer

### DIFF
--- a/scripts/installer/install.py
+++ b/scripts/installer/install.py
@@ -413,7 +413,7 @@ if podName != "start-glassfish" and podName != "dataverse-glassfish-0" and not s
 
    # 3e. set permissions:
 
-   conn_cmd = "GRANT CREATE PRIVILEGES on DATABASE "+pgDb+" to "+pgUser+";"
+   conn_cmd = "GRANT ALL PRIVILEGES on DATABASE "+pgDb+" to "+pgUser+";"
    try:
       cur.execute(conn_cmd)
    except:


### PR DESCRIPTION
The installer script contained invalid SQL which caused the install from scratch to fail. This has been fixed in 6.1. Back-ported the fix.