### PR TITLE
PATCH-1 Exlude mime4j depedencies via sword2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <groupId>io.gdcc</groupId>
             <artifactId>sword2-server</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.james</groupId>
+                    <artifactId>apache-mime4j-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Dependency to use sword2-server in our codebase -->
         <dependency>


### PR DESCRIPTION
Exlude mime4j depedencies via sword2, as they win out over the correct versions
Issue: https://github.com/IQSS/dataverse/issues/9077

**What this PR does / why we need it**:

Re-appying the PATCH-1 we had on version 6.0
Part of upgrading from 6.0 to 6.2
More patches are needed

**Suggestions on how to test this**:

Prepare a system with the patched version of Dataverse.

1. First you need a server to deploy on; the Vagrant boxes we use need some updating before it will work. 
Use another PR on dans-core-systems (https://github.com/DANS-KNAW/dans-core-systems/pull/30) for that; it will provide for the following to update:
`start-preprovisioned-box.py -s dev_archaeology`. 
2. Then fix the database, it contains a wrong flyway record:
    ```
    vagrant ssh dev_archaeology
    sudo -u postgres psql
    \c dvndb
    DELETE FROM flyway_schema_history WHERE script='V6.0.0.2__9983-missing-unique-constraints.sql';
    ```
3. Deploy the update with the IQSS 6.2 version first:
`deploy.py --playbook provisioning/patches/upgrade-dataverse/to-6.2.yml dev_archaeology`. 
4. Then deploy the war file of this PR, after a build `mvnci`. `deploy.py --dataverse-war external/dataverse/target/dataverse`. 

Then test it with a file that would show the error if it was not fixed. 

1. Enable full text indexing:
    ```
    vagrant ssh dev_archaeology
    curl -X PUT -d true http://localhost:8080/api/admin/settings/:SolrFullTextIndexing
    ```
2. Login, create a dataset and upload that file. 
3. Check that the Logs don't show that ERROR; `Full-text indexing for email.txt failed due to Error: java.lang.NoClassDefFoundError : org/apache/james/mime4j/stream/MimeConfig$Builder`.
4. Check that the file has been indexed; search for 'peripatetic' should result in that file. 

