### PR TITLE
DD-1752: File history viewer doesn´t display differences

### DIFF
--- a/doc/release-notes/11142-more-detailed-file-differences.md
+++ b/doc/release-notes/11142-more-detailed-file-differences.md
@@ -1,0 +1,3 @@
+The file page version table now shows more detail, e.g. when there are metadata changes or whether a file has been replaced. 
+A bug that causes adding free-form provenance to a file to fail has been fixed.
+See also #11142 and #11145.

--- a/modules/dataverse-parent/pom.xml
+++ b/modules/dataverse-parent/pom.xml
@@ -131,7 +131,7 @@
  
     <properties>
         <!-- This is a special Maven property name, do not change! -->
-        <revision>6.4</revision>
+        <revision>6.5</revision>
     
         <target.java.version>17</target.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetVersionDifference.java
@@ -373,9 +373,9 @@ public final class DatasetVersionDifference {
                     List.of(fmdo.getLabel(), fmdn.getLabel()));
         }
         
-        if (!StringUtils.equals(fmdo.getProvFreeForm(), fmdn.getProvFreeForm())) {
+        if (!StringUtils.equals(StringUtil.nullToEmpty(fmdo.getProvFreeForm()), StringUtil.nullToEmpty(fmdn.getProvFreeForm()))) {
             fileMetadataChanged.put("ProvFreeForm",
-                    List.of(fmdo.getProvFreeForm(), fmdn.getProvFreeForm()));
+                    List.of(StringUtil.nullToEmpty(fmdo.getProvFreeForm()), StringUtil.nullToEmpty(fmdn.getProvFreeForm())));
         }
 
         if (fmdo.isRestricted() != fmdn.isRestricted()) {

--- a/src/main/java/edu/harvard/iq/dataverse/FilePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/FilePage.java
@@ -708,7 +708,7 @@ public class FilePage implements java.io.Serializable {
                     FileMetadata fmd = datafileService.findFileMetadataByDatasetVersionIdAndDataFileId(versionLoop.getId(), df.getId());
                     if (fmd != null) {
                         fmd.setContributorNames(datasetVersionService.getContributorsNames(versionLoop));
-                        FileVersionDifference fvd = new FileVersionDifference(fmd, getPreviousFileMetadata(fmd));
+                        FileVersionDifference fvd = new FileVersionDifference(fmd, getPreviousFileMetadata(fmd), true);
                         fmd.setFileVersionDifference(fvd);
                         retList.add(fmd);
                         foundFmd = true;
@@ -720,7 +720,7 @@ public class FilePage implements java.io.Serializable {
                     FileMetadata dummy = new FileMetadata();
                     dummy.setDatasetVersion(versionLoop);
                     dummy.setDataFile(null);
-                    FileVersionDifference fvd = new FileVersionDifference(dummy, getPreviousFileMetadata(versionLoop));
+                    FileVersionDifference fvd = new FileVersionDifference(dummy, getPreviousFileMetadata(versionLoop), true);
                     dummy.setFileVersionDifference(fvd);
                     retList.add(dummy);
                 }


### PR DESCRIPTION
We should have the same differences as https://github.com/IQSS/dataverse/pull/11145/files
* [x] deploy on `dev_archaeology_V6-5_2025-01-21.box`
* [x] test as in https://github.com/IQSS/dataverse/issues/11142

Screenshots of the test results look okay
https://github.com/IQSS/dataverse/pull/11145 suggests to also test free-form provenance, the VM does not have that option.

---

![image](https://github.com/user-attachments/assets/a3c958e0-7cf0-4a7d-b939-45f0ec67b046)

---

![image](https://github.com/user-attachments/assets/eb37b3ba-3a44-4025-b463-66855351fa57)
