### PR TITLE
DD-1775: content type of vtt files for new datasets

### DIFF
--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -16,6 +16,7 @@ mat=application/matlab-mat
 md=text/markdown
 mp3=audio/mp3
 m4a=audio/mp4
+vtt=text/vtt
 nii=image/nii
 nc=application/netcdf
 ods=application/vnd.oasis.opendocument.spreadsheet

--- a/src/main/java/propertyFiles/MimeTypeDisplay.properties
+++ b/src/main/java/propertyFiles/MimeTypeDisplay.properties
@@ -217,6 +217,7 @@ video/x-m4v=MPEG-4 Video
 video/ogg=OGG Video
 video/quicktime=Quicktime Video
 video/webm=WebM Video
+text/vtt=Web Video Text Tracks
 # Network Data
 text/xml-graphml=GraphML Network Data
 # 3D Data

--- a/src/main/java/propertyFiles/MimeTypeFacets.properties
+++ b/src/main/java/propertyFiles/MimeTypeFacets.properties
@@ -30,6 +30,7 @@ text/richtext=Text
 text/turtle=Text
 application/xml=Text
 text/xml=Text
+text/vtt=Text
 # Code
 text/x-c=Code
 text/x-c++src=Code


### PR DESCRIPTION
how to test 
--------------

* start dev_archaeology_V6-5_PATCH3_2025-02-08.box
* create a dataset and upload https://github.com/user-attachments/files/18197712/test-files-subtitles.zip
* publish the dataset
* file facet search shows the uploaded files as unknown
* build dataverse
* on dans-core-systems `deploy.py --dataverse-war external/dataverse/target/dataverse`
* on the VM `curl -X PUT -d true http://localhost:8080/api/admin/settings/:SolrFullTextIndexing`
* create another dataset with the same zip and publish
* the metadata of the new dataset shows the results expected in the issue, the first dataset is displayed the same
* the new files appear under the file facets, searching for "Beispiel" pops up only the public German vtt file

Related PRs
---------------

* Same changes approved at IQSS https://github.com/IQSS/dataverse/pull/11300
* https://github.com/DANS-KNAW/dans-core-systems/pull/142
* https://github.com/DANS-KNAW/dans-core-systems/pull/143
* https://github.com/DANS-KNAW/dans-core-systems/pull/168
