### PR TITLE
DD-1783: blocked page because of not found host dataverse

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -141,7 +141,6 @@ import jakarta.faces.component.UIInput;
 import jakarta.faces.event.AjaxBehaviorEvent;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -334,6 +333,7 @@ public class DatasetPage implements java.io.Serializable {
     private List<SelectItem> linkingDVSelectItems;
     private Dataverse linkingDataverse;
     private Dataverse selectedHostDataverse;
+    private boolean hasDataversesToChoose;
 
     public Dataverse getSelectedHostDataverse() {
         return selectedHostDataverse;
@@ -1764,6 +1764,11 @@ public class DatasetPage implements java.io.Serializable {
 
     public void setDataverseTemplates(List<Template> dataverseTemplates) {
         this.dataverseTemplates = dataverseTemplates;
+    }
+
+    public boolean isHasDataversesToChoose() {
+        this.hasDataversesToChoose = dataverseService.findAll().size() > 1;
+        return this.hasDataversesToChoose;
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
@@ -26,7 +26,13 @@ public class DataverseConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent component, String submittedValue) {
-        return dataverseService.find(new Long(submittedValue));
+        if (submittedValue == null || submittedValue.isEmpty()) {
+            return "";
+        }
+        if (submittedValue.matches(".*[^0-9].*")) {
+            return submittedValue;
+        }
+        return dataverseService.find(Long.valueOf(submittedValue));
         //return dataverseService.findByAlias(submittedValue);
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
@@ -26,13 +26,9 @@ public class DataverseConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent component, String submittedValue) {
-        if (submittedValue == null || submittedValue.isEmpty()) {
-            return "";
-        }
-        if (submittedValue.matches(".*[^0-9].*")) {
-            return submittedValue;
-        }
-        return dataverseService.find(Long.valueOf(submittedValue));
+        var pk = (submittedValue == null || submittedValue.isEmpty() || submittedValue.matches(".*[^0-9].*"))
+        ? 0 : Long.valueOf(submittedValue);
+        return dataverseService.find(pk);
         //return dataverseService.findByAlias(submittedValue);
     }
 

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -737,7 +737,7 @@
                     <!-- Create/Edit editMode -->
                     <ui:fragment rendered="#{DatasetPage.editMode == 'METADATA' or DatasetPage.editMode == 'CREATE'}">
                         <p:focus context="datasetForm"/>
-                        <div class="form-group">
+                        <div class="form-group" jsf:rendered="#{DatasetPage.hasDataversesToChoose and DatasetPage.editMode == 'CREATE'}">
                             <label jsf:for="#{DatasetPage.editMode == 'CREATE' ? 'selectHostDataverse_input' : 'select_HostDataverse_Static'}" class="col-md-3 control-label">
                                 #{bundle.hostDataverse}
                                 <span class="glyphicon glyphicon-question-sign tooltip-icon"


### PR DESCRIPTION
**What this PR does / why we need it**:

A dataset is not saved and there is no option to correct the mistake if you edit the “Host Dataverse” field and immediately correct and leave it. When clicking Save the page freezes and after a hard refresh all your metadata is gone and you have to start over. Reproduced in 6.3 and 6.5 (DANS branches).

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

Not sure about the impact when templates are used. See https://github.com/IQSS/dataverse/pull/11301#issuecomment-2701917692

**Suggestions on how to test this**:

1. In the user interface click Add Data → New Dataset
2. The cursor is placed in the “Host Dataverse” field.
3. Type a space, remove it and quickly put the cursor in the title field.
4. Fill in the required fields and click Save.

Not tested with templates.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:

@DANS-KNAW/core-systems 
