### PR TITLE
DD-1783: accidentally touching "Host Dataverse"

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
@@ -28,6 +28,7 @@ public class DataverseConverter implements Converter {
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent component, String submittedValue) {
+
         if (submittedValue == null || !submittedValue.matches("[0-9]+")) {
             logger.fine("Submitted value is not a host dataverse number but: " + submittedValue);
             return CDI.current().select(DatasetPage.class).get().getSelectedHostDataverse();

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
@@ -13,22 +13,28 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.FacesConverter;
 
+import java.util.logging.Logger;
+
 /**
  *
  * @author skraffmiller
  */
 @FacesConverter("dataverseConverter")
 public class DataverseConverter implements Converter {
-
+    private static final Logger logger = Logger.getLogger(DatasetPage.class.getCanonicalName());
     
     //@EJB
     DataverseServiceBean dataverseService = CDI.current().select(DataverseServiceBean.class).get();
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent component, String submittedValue) {
-        var pk = (submittedValue == null || submittedValue.isEmpty() || submittedValue.matches(".*[^0-9].*"))
-        ? 0 : Long.valueOf(submittedValue);
-        return dataverseService.find(pk);
+        if (submittedValue == null || !submittedValue.matches("[0-9]+")) {
+            logger.fine("Submitted value is not a host dataverse number but: " + submittedValue);
+            return CDI.current().select(DatasetPage.class).get().getSelectedHostDataverse();
+        }
+        else {
+            return dataverseService.find(Long.valueOf(submittedValue));
+        }
         //return dataverseService.findByAlias(submittedValue);
     }
 


### PR DESCRIPTION
https://github.com/IQSS/dataverse/pull/11301

**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

See also https://github.com/IQSS/dataverse/pull/11301#pullrequestreview-2888809447

Rephrased by mail:

> If I have a “test” collection and I create a dataset in it, the host collection starts as “test”. If I edit/delete there, it used to cause a null pointer (if I understand) but now, with your change, will default to the “root” collection. If I try to save that dataset, and don’t have permissions to create a dataset in the “root” collection (say I only have permissions to create one in the “test” collection), what happens? I assume it would fail. (If not, it would be worse if I actually can create a dataset in root this way).

 

> My suggestion was that it might be more robust to treat a null as invalid and not change the host dataverse from what it was (versus defaulting to root). I haven’t tried to do this, so my suggestion of just not updating in the DatasetPage code might not work. 

**Suggestions on how to test this**:

In a dataversenl environment, or add dataverses to a VM

1. In the user interface click Add Data → New Dataset
2. The cursor is placed in the “Host Dataverse” field.
3. Quickly type: space, back-space, tab
4. Fill in the required fields and click Save.

Fine logging of DataverseConverter will show the name of the initial dataverse.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
