### PR TITLE
DD-1983: clearAllCachedFormats by DestroyDatasetCommand

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
@@ -9,10 +9,6 @@ import edu.harvard.iq.dataverse.authorization.DataverseRole;
 import edu.harvard.iq.dataverse.dataaccess.DataAccess;
 import edu.harvard.iq.dataverse.dataaccess.FileAccessIO;
 import edu.harvard.iq.dataverse.dataaccess.GlobusOverlayAccessIO;
-import edu.harvard.iq.dataverse.dataaccess.RemoteOverlayAccessIO;
-import edu.harvard.iq.dataverse.dataaccess.S3AccessIO;
-import edu.harvard.iq.dataverse.dataaccess.StorageIO;
-import edu.harvard.iq.dataverse.dataaccess.SwiftAccessIO;
 import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.RoleAssignment;
@@ -31,9 +27,7 @@ import edu.harvard.iq.dataverse.pidproviders.PidProvider;
 import edu.harvard.iq.dataverse.pidproviders.PidUtil;
 import edu.harvard.iq.dataverse.search.IndexResponse;
 
-import java.io.File;
 import java.nio.file.Files;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -43,7 +37,7 @@ import java.util.logging.Logger;
 
 import edu.harvard.iq.dataverse.batch.util.LoggingUtil;
 import java.io.IOException;
-import java.util.concurrent.Future;
+
 import org.apache.solr.client.solrj.SolrServerException;
 
 /**

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
@@ -6,6 +6,7 @@ import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.GlobalId;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
+import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.RoleAssignment;
 import edu.harvard.iq.dataverse.authorization.Permission;
@@ -96,8 +97,16 @@ public class DestroyDatasetCommand extends AbstractVoidCommand {
         // ROLES
         for (DataverseRole ra : ctxt.roles().findByOwnerId(managedDoomed.getId())) {
             ctxt.em().remove(ra);
-        }   
-        
+        }
+
+        ExportService exportService = ExportService.getInstance();
+        try {
+            exportService.clearAllCachedFormats(doomed);
+        }
+        catch (IOException e) {
+            logger.log(Level.WARNING, "Export service could not clear all cached formats:", e.getMessage());
+        }
+
         if (!managedDoomed.isHarvested()) {
             //also, lets delete the uploaded thumbnails!
             deleteDatasetLogo(managedDoomed);

--- a/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
+++ b/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/DestroyDatasetCommand.java
@@ -6,12 +6,21 @@ import edu.harvard.iq.dataverse.DatasetVersion;
 import edu.harvard.iq.dataverse.Dataverse;
 import edu.harvard.iq.dataverse.GlobalId;
 import edu.harvard.iq.dataverse.authorization.DataverseRole;
+import edu.harvard.iq.dataverse.dataaccess.DataAccess;
+import edu.harvard.iq.dataverse.dataaccess.FileAccessIO;
+import edu.harvard.iq.dataverse.dataaccess.GlobusOverlayAccessIO;
+import edu.harvard.iq.dataverse.dataaccess.RemoteOverlayAccessIO;
+import edu.harvard.iq.dataverse.dataaccess.S3AccessIO;
+import edu.harvard.iq.dataverse.dataaccess.StorageIO;
+import edu.harvard.iq.dataverse.dataaccess.SwiftAccessIO;
 import edu.harvard.iq.dataverse.export.ExportService;
 import edu.harvard.iq.dataverse.search.IndexServiceBean;
 import edu.harvard.iq.dataverse.RoleAssignment;
 import edu.harvard.iq.dataverse.authorization.Permission;
 import edu.harvard.iq.dataverse.authorization.users.AuthenticatedUser;
 import static edu.harvard.iq.dataverse.dataset.DatasetUtil.deleteDatasetLogo;
+import static java.text.MessageFormat.format;
+
 import edu.harvard.iq.dataverse.engine.command.AbstractVoidCommand;
 import edu.harvard.iq.dataverse.engine.command.CommandContext;
 import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
@@ -21,6 +30,10 @@ import edu.harvard.iq.dataverse.engine.command.exception.PermissionException;
 import edu.harvard.iq.dataverse.pidproviders.PidProvider;
 import edu.harvard.iq.dataverse.pidproviders.PidUtil;
 import edu.harvard.iq.dataverse.search.IndexResponse;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -99,14 +112,6 @@ public class DestroyDatasetCommand extends AbstractVoidCommand {
             ctxt.em().remove(ra);
         }
 
-        ExportService exportService = ExportService.getInstance();
-        try {
-            exportService.clearAllCachedFormats(doomed);
-        }
-        catch (IOException e) {
-            logger.log(Level.WARNING, "Export service could not clear all cached formats:", e.getMessage());
-        }
-
         if (!managedDoomed.isHarvested()) {
             //also, lets delete the uploaded thumbnails!
             deleteDatasetLogo(managedDoomed);
@@ -124,7 +129,29 @@ public class DestroyDatasetCommand extends AbstractVoidCommand {
                 }
             }
         }
-        
+
+        // CACHED EXPORTS
+        var exportService = ExportService.getInstance();
+        try {
+            exportService.clearAllCachedFormats(managedDoomed);
+        }
+        catch (IOException e) {
+            var msg = format("Failed to delete cached exports of {0}: {1} ", managedDoomed.getIdentifier(), e.getClass().getSimpleName());
+            logger.log(Level.WARNING, msg, e.getMessage());
+        }
+
+        // DIRECTORY
+        try {
+            var storageIO = DataAccess.getStorageIO(managedDoomed);
+            if (storageIO instanceof FileAccessIO<Dataset> || storageIO instanceof GlobusOverlayAccessIO<Dataset>) {
+                Files.delete(storageIO.getAuxObjectAsPath(".").getParent());
+            }
+        }
+        catch (IOException e) {
+            var msg = format("Failed to delete dataset directory of {0}: {1} ", managedDoomed.getIdentifier(), e.getClass().getSimpleName());
+            logger.log(Level.WARNING, msg, e.getMessage());
+        }
+
         toReIndex = managedDoomed.getOwner();
 
         // add potential Solr IDs of datasets to list for deletion


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes https://github.com/IQSS/dataverse/issues/11470

**Special notes for your reviewer**:

**Suggestions on how to test this**:

With `dev_archaeology-2025-07-09.box` 

Figure out the dataset ID by exporting the metatada, for example `7` for `10.5072/DAR/QNQRNQ`

    export API_TOKEN='X-Dataverse-key:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
    curl -k -H "$API_TOKEN" -X DELETE "https://dev.archaeology.datastations.nl/api/datasets/7/destroy/"

After destroy 

    ls -l /data/dataverse/files/10.5072/DAR/QNQRNQ/

Before deploy you will see files like `export_*.cached`, after deploy, the directory will be gone.

Add some rogue file to the directory of another dataset. Destroy it too. The payara log will show a message like:

    Failed to delete dataset directory of DAR/QNQRNQ: DirectoryNotEmptyException

Not tested with GlobusOverlayAccessIO or S3.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
