### PR TITLE
DD-1818: optimistic lock related to tabular ingest (as IQSS PRs)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/RoleAssignment.java
+++ b/src/main/java/edu/harvard/iq/dataverse/RoleAssignment.java
@@ -64,7 +64,7 @@ public class RoleAssignment implements java.io.Serializable {
 	@JoinColumn( nullable=false )
 	private DataverseRole role;
 	
-	@ManyToOne( cascade = {CascadeType.MERGE} ) 
+	@ManyToOne
 	@JoinColumn( nullable=false )
 	private DvObject definitionPoint;
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -69,6 +69,7 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -2135,6 +2136,11 @@ public class Datasets extends AbstractApiBean {
             return ok(
                     json(execCommand(new AssignRoleCommand(assignee, theRole, dataset, createDataverseRequest(getRequestUser(crc)), privateUrlToken))));
         } catch (WrappedResponse ex) {
+            var message = ExceptionUtils.getRootCause(ex).getMessage();
+            if (message != null && message.contains("duplicate key")) {
+                // concurrent update
+                return error(Status.CONFLICT, BundleUtil.getStringFromBundle("datasets.api.grant.role.assignee.has.role.error"));
+            }
             List<String> args = Arrays.asList(ex.getMessage());
             logger.log(Level.WARNING, BundleUtil.getStringFromBundle("datasets.api.grant.role.cant.create.assignment.error", args));
             return ex.getResponse();


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

See _steps to replicate_ in [DD-1818](https://drivenbydata.atlassian.net/browse/DD-1818)
Before deploy a few transactions were aborted, after none.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:


[DD-1818]: https://drivenbydata.atlassian.net/browse/DD-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ