### PR TITLE
DD-1783: restored suppression of host dataverse

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DatasetPage.java
@@ -1,5 +1,8 @@
 package edu.harvard.iq.dataverse;
 
+import edu.harvard.iq.dataverse.authorization.DataverseRole;
+import edu.harvard.iq.dataverse.engine.command.DataverseRequest;
+import edu.harvard.iq.dataverse.globus.Permissions;
 import edu.harvard.iq.dataverse.provenance.ProvPopupFragmentBean;
 import edu.harvard.iq.dataverse.api.AbstractApiBean;
 import edu.harvard.iq.dataverse.authorization.AuthenticationServiceBean;
@@ -331,6 +334,7 @@ public class DatasetPage implements java.io.Serializable {
     private List<SelectItem> linkingDVSelectItems;
     private Dataverse linkingDataverse;
     private Dataverse selectedHostDataverse;
+    private Boolean hasDataversesToChoose;
 
     public Dataverse getSelectedHostDataverse() {
         return selectedHostDataverse;
@@ -1770,6 +1774,22 @@ public class DatasetPage implements java.io.Serializable {
 
     public void setDataverseTemplates(List<Template> dataverseTemplates) {
         this.dataverseTemplates = dataverseTemplates;
+    }
+
+    public boolean isHasDataversesToChoose() {
+
+        if (this.hasDataversesToChoose == null) {
+            var user = this.session.getUser();
+            if (!user.isAuthenticated()) {
+                this.hasDataversesToChoose = false;
+            } else {
+                var req = dvRequestService.getDataverseRequest();
+                var permissionBit = 1 << Permission.AddDataset.ordinal();
+                var authenticatedUser = (AuthenticatedUser) user;
+                this.hasDataversesToChoose = permissionService.hasMultiplePermittedCollections(req, authenticatedUser, permissionBit);
+            }
+        }
+        return this.hasDataversesToChoose;
     }
 
     public Template getDefaultTemplate() {

--- a/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataverseConverter.java
@@ -13,19 +13,34 @@ import jakarta.faces.context.FacesContext;
 import jakarta.faces.convert.Converter;
 import jakarta.faces.convert.FacesConverter;
 
+import java.util.logging.Logger;
+
 /**
  *
  * @author skraffmiller
  */
 @FacesConverter("dataverseConverter")
 public class DataverseConverter implements Converter {
+    private static final Logger logger = Logger.getLogger(DataverseConverter.class.getCanonicalName());
+
     
     //@EJB
     DataverseServiceBean dataverseService = CDI.current().select(DataverseServiceBean.class).get();
 
     @Override
     public Object getAsObject(FacesContext facesContext, UIComponent component, String submittedValue) {
-        return dataverseService.find(new Long(submittedValue));
+        if (submittedValue == null || !submittedValue.matches("[0-9]+")) {
+            logger.fine("Submitted value is not a host dataverse number but: " + submittedValue);
+            return CDI.current().select(DatasetPage.class).get().getSelectedHostDataverse();
+        }
+        else {
+            try {
+                return dataverseService.find(Long.parseLong(submittedValue));
+            } catch (NumberFormatException e) {
+                logger.warning("Submitted value is out of range for a Long: " + submittedValue);
+                return CDI.current().select(DatasetPage.class).get().getSelectedHostDataverse();
+            }
+        }
         //return dataverseService.findByAlias(submittedValue);
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/PermissionServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/PermissionServiceBean.java
@@ -929,39 +929,52 @@ public class PermissionServiceBean {
     public List<Dataverse> findPermittedCollections(DataverseRequest request, AuthenticatedUser user, int permissionBit) {
         if (user != null) {
             // IP Group - Only check IP if a User is calling for themself
-            String ipRangeSQL = "FALSE";
-            if (request != null
-                    && request.getAuthenticatedUser() != null
-                    && request.getSourceAddress() != null
-                    && request.getAuthenticatedUser().getUserIdentifier().equalsIgnoreCase(user.getUserIdentifier())) {
-                IpAddress ip = request.getSourceAddress();
-                if (ip instanceof IPv4Address) {
-                    IPv4Address ipv4 = (IPv4Address) ip;
-                    ipRangeSQL = ipv4.toBigInteger() + " BETWEEN ipv4range.bottomaslong AND ipv4range.topaslong";
-                } else if (ip instanceof IPv6Address) {
-                    IPv6Address ipv6 = (IPv6Address) ip;
-                    long[] vals = ipv6.toLongArray();
-                    if (vals.length == 4) {
-                        ipRangeSQL = """
-                                (@0 BETWEEN ipv6range.bottoma AND ipv6range.topa
-                                AND @1 BETWEEN ipv6range.bottomb AND ipv6range.topb
-                                AND @2 BETWEEN ipv6range.bottomc AND ipv6range.topc
-                                AND @3 BETWEEN ipv6range.bottomd AND ipv6range.topd)
-                                """;
-                        for (int i = 0; i < vals.length; i++) {
-                            ipRangeSQL = ipRangeSQL.replace("@" + i, String.valueOf(vals[i]));
-                        }
-                    }
-                }
-            }
-
-            String sqlCode = LIST_ALL_DATAVERSES_USER_HAS_PERMISSION
-                    .replace("@USERID", String.valueOf(user.getId()))
-                    .replace("@PERMISSIONBIT", String.valueOf(permissionBit))
-                    .replace("@IPRANGESQL", ipRangeSQL);
+            var sqlCode = getSqlCode(request, user, permissionBit);
             return em.createNativeQuery(sqlCode, Dataverse.class).getResultList();
         }
         return null;
+    }
+
+    public boolean hasMultiplePermittedCollections(DataverseRequest request, AuthenticatedUser user, int permissionBit) {
+        if (user != null) {
+            var sqlCode = getSqlCode(request, user, permissionBit) + " LIMIT 2";
+            var resultList = em.createNativeQuery(sqlCode, Dataverse.class).getResultList();
+            return resultList.size() > 1;
+        }
+        return false;
+    }
+
+    private String getSqlCode(DataverseRequest request, AuthenticatedUser user, int permissionBit) {
+        String ipRangeSQL = "FALSE";
+        if (request != null
+            && request.getAuthenticatedUser() != null
+            && request.getSourceAddress() != null
+            && request.getAuthenticatedUser().getUserIdentifier().equalsIgnoreCase(user.getUserIdentifier())) {
+            IpAddress ip = request.getSourceAddress();
+            if (ip instanceof IPv4Address) {
+                IPv4Address ipv4 = (IPv4Address) ip;
+                ipRangeSQL = ipv4.toBigInteger() + " BETWEEN ipv4range.bottomaslong AND ipv4range.topaslong";
+            } else if (ip instanceof IPv6Address) {
+                IPv6Address ipv6 = (IPv6Address) ip;
+                long[] vals = ipv6.toLongArray();
+                if (vals.length == 4) {
+                    ipRangeSQL = """
+                            (@0 BETWEEN ipv6range.bottoma AND ipv6range.topa
+                            AND @1 BETWEEN ipv6range.bottomb AND ipv6range.topb
+                            AND @2 BETWEEN ipv6range.bottomc AND ipv6range.topc
+                            AND @3 BETWEEN ipv6range.bottomd AND ipv6range.topd)
+                            """;
+                    for (int i = 0; i < vals.length; i++) {
+                        ipRangeSQL = ipRangeSQL.replace("@" + i, String.valueOf(vals[i]));
+                    }
+                }
+            }
+        }
+
+        return LIST_ALL_DATAVERSES_USER_HAS_PERMISSION
+                .replace("@USERID", String.valueOf(user.getId()))
+                .replace("@PERMISSIONBIT", String.valueOf(permissionBit))
+                .replace("@IPRANGESQL", ipRangeSQL);
     }
 }
 

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -753,7 +753,7 @@
                     <!-- Create/Edit editMode -->
                     <ui:fragment rendered="#{DatasetPage.editMode == 'METADATA' or DatasetPage.editMode == 'CREATE'}">
                         <p:focus context="datasetForm"/>
-                        <div class="form-group">
+                        <div class="form-group" jsf:rendered="#{DatasetPage.hasDataversesToChoose and DatasetPage.editMode == 'CREATE'}">
                             <label jsf:for="#{DatasetPage.editMode == 'CREATE' ? 'selectHostDataverse_input' : 'select_HostDataverse_Static'}" class="col-md-3 control-label">
                                 #{bundle.hostDataverse}
                                 <span class="glyphicon glyphicon-question-sign tooltip-icon"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

When creating a new datasets on DANS-v6.5, the host-dataverse field was suppressed on the data stations (which only has a root dataverse) but not on dataversenl (which has multiple dataverses). The field will now be suppressed for users that have no permission to create datasets on other dataverses than the root.

**Is there a release notes update needed for this change?**:

**Additional documentation**:
