### PR TITLE
DD-2093 Format multi-line bag-info.txt values

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
@@ -827,7 +827,7 @@ public class BagGenerator {
         // ToDo - make configurable
         info.append(CRLF);
 
-        info.append("Organization-Address: " + WordUtils.wrap(orgAddress, 78, CRLF + " ", true));
+        info.append("Organization-Address: " + wrapAndIndent(orgAddress));
 
         info.append(CRLF);
 
@@ -847,8 +847,8 @@ public class BagGenerator {
         } else {
             info.append(
                     // FixMe - handle description having subfields better
-                    WordUtils.wrap(getSingleValue(aggregation.get(descriptionTerm.getLabel()),
-                            descriptionTextTerm.getLabel()), 78, CRLF + " ", true));
+                    wrapAndIndent(getSingleValue(aggregation.get(descriptionTerm.getLabel()),
+                            descriptionTextTerm.getLabel())));
 
             info.append(CRLF);
         }
@@ -914,6 +914,43 @@ public class BagGenerator {
             logger.fine("Multiple values found for: " + key + ": " + val);
         }
         return val;
+    }
+
+    /**
+     * Wraps the provided value to 78 characters with BagIt-compliant continuation
+     * lines and ensures that any existing newlines within the value are treated as
+     * line breaks whose subsequent lines begin with two spaces, as used elsewhere
+     * in bag-info.txt.
+     */
+    private String wrapAndIndent(String value) {
+        if (value == null) {
+            return "";
+        }
+        final String continuation = CRLF + "  "; // two-space indent for continued lines
+        // Normalize newline variants to \n for processing
+        String normalized = value.replace("\r\n", "\n").replace("\r", "\n");
+
+        // Split on existing newlines and wrap each segment separately so we can
+        // inject exactly one CRLF at embedded newline boundaries and ensure the
+        // two-space indent is counted toward the 78-char width.
+        String[] segments = normalized.split("\n", -1);
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < segments.length; i++) {
+            String segment = segments[i];
+            if (i == 0) {
+                // First segment: wrap as-is
+                out.append(WordUtils.wrap(segment, 78, continuation, true));
+            } else {
+                // Embedded newline: add a single CRLF, then add the two-space indent only once
+                // for the first line following the newline. For the content after the indent,
+                // wrap to a width of 76 so the total line length (including the two spaces)
+                // does not exceed 78. Additional wrapped lines will use the continuation
+                // (CRLF + two spaces) automatically.
+                out.append(CRLF).append("  ");
+                out.append(WordUtils.wrap(segment, 76, continuation, true));
+            }
+        }
+        return out.toString();
     }
 
     // Used in validation

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
@@ -248,7 +248,7 @@ public class BagGenerator {
         boolean first = true;
         for (Entry<String, String> pidEntry : pidMap.entrySet()) {
             if (!first) {
-                pidStringBuffer.append("\r\n");
+                pidStringBuffer.append(CRLF);
             } else {
                 first = false;
             }
@@ -263,7 +263,7 @@ public class BagGenerator {
         first = true;
         for (Entry<String, String> sha1Entry : checksumMap.entrySet()) {
             if (!first) {
-                sha1StringBuffer.append("\r\n");
+                sha1StringBuffer.append(CRLF);
             } else {
                 first = false;
             }
@@ -289,7 +289,7 @@ public class BagGenerator {
             createFileFromString("manifest-md5.txt", "");
         }
         // bagit.txt - Required by spec
-        createFileFromString("bagit.txt", "BagIt-Version: 1.0\r\nTag-File-Character-Encoding: UTF-8");
+        createFileFromString("bagit.txt", "BagIt-Version: 1.0" + CRLF + "Tag-File-Character-Encoding: UTF-8");
 
         aggregation.addProperty(JsonLDTerm.totalSize.getLabel(), totalDataSize);
         aggregation.addProperty(JsonLDTerm.fileCount.getLabel(), dataCount);
@@ -758,6 +758,11 @@ public class BagGenerator {
     }
 
     static final String CRLF = "\r\n";
+    static final String LF = "\n";
+    static final String CR = "\r";
+    // BagIt/BagPack formatting constants
+    private static final int BAGINFO_WRAP_WIDTH = 78;
+    private static final String CONTINUATION_INDENT = "  ";
 
     private String generateInfoFile() {
         logger.fine("Generating info file");
@@ -917,7 +922,7 @@ public class BagGenerator {
     }
 
     /**
-     * Wraps the provided value to 78 characters with BagIt-compliant continuation
+     * Wraps the provided value to BAGINFO_WRAP_WIDTH characters with BagIt-compliant continuation
      * lines and ensures that any existing newlines within the value are treated as
      * line breaks whose subsequent lines begin with two spaces, as used elsewhere
      * in bag-info.txt.
@@ -926,28 +931,29 @@ public class BagGenerator {
         if (value == null) {
             return "";
         }
-        final String continuation = CRLF + "  "; // two-space indent for continued lines
-        // Normalize newline variants to \n for processing
-        String normalized = value.replace("\r\n", "\n").replace("\r", "\n");
+        final String continuation = CRLF + CONTINUATION_INDENT;
+        final int widthAfterIndent = BAGINFO_WRAP_WIDTH - CONTINUATION_INDENT.length();
+        // Normalize newline variants to LF for processing
+        String normalized = value.replace(CRLF, LF).replace(CR, LF);
 
         // Split on existing newlines and wrap each segment separately so we can
         // inject exactly one CRLF at embedded newline boundaries and ensure the
-        // two-space indent is counted toward the 78-char width.
-        String[] segments = normalized.split("\n", -1);
+        // two-space indent is counted toward the BAGINFO_WRAP_WIDTH-char width.
+        String[] segments = normalized.split(LF, -1);
         StringBuilder out = new StringBuilder();
         for (int i = 0; i < segments.length; i++) {
             String segment = segments[i];
             if (i == 0) {
                 // First segment: wrap as-is
-                out.append(WordUtils.wrap(segment, 78, continuation, true));
+                out.append(WordUtils.wrap(segment, BAGINFO_WRAP_WIDTH, continuation, true));
             } else {
                 // Embedded newline: add a single CRLF, then add the two-space indent only once
                 // for the first line following the newline. For the content after the indent,
                 // wrap to a width of 76 so the total line length (including the two spaces)
-                // does not exceed 78. Additional wrapped lines will use the continuation
+                // does not exceed BAGINFO_WRAP_WIDTH. Additional wrapped lines will use the continuation
                 // (CRLF + two spaces) automatically.
-                out.append(CRLF).append("  ");
-                out.append(WordUtils.wrap(segment, 76, continuation, true));
+                out.append(CRLF).append(CONTINUATION_INDENT);
+                out.append(WordUtils.wrap(segment, widthAfterIndent, continuation, true));
             }
         }
         return out.toString();

--- a/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagGeneratorTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagGeneratorTest.java
@@ -1,0 +1,62 @@
+package edu.harvard.iq.dataverse.util.bagit;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BagGeneratorTest {
+
+    private static String invokeWrapAndIndent(BagGenerator instance, String input) throws Exception {
+        Method m = BagGenerator.class.getDeclaredMethod("wrapAndIndent", String.class);
+        m.setAccessible(true);
+        return (String) m.invoke(instance, input);
+    }
+
+    @Test
+    void wrapAndIndent_nullReturnsEmpty() throws Exception {
+        BagGenerator bg = Mockito.mock(BagGenerator.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        String out = invokeWrapAndIndent(bg, null);
+        assertEquals("", out);
+    }
+
+    @Test
+    void wrapAndIndent_embeddedNewlinesAreIndented() throws Exception {
+        BagGenerator bg = Mockito.mock(BagGenerator.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        String input = "Line1\nLine2\nLine3";
+        String out = invokeWrapAndIndent(bg, input);
+        String expected = "Line1\r\n  Line2\r\n  Line3";
+        assertEquals(expected, out);
+    }
+
+    @Test
+    void wrapAndIndent_longLineWrapsAt78WithTwoSpaceContinuation() throws Exception {
+        BagGenerator bg = Mockito.mock(BagGenerator.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        String input = "a".repeat(100);
+
+        String out = invokeWrapAndIndent(bg, input);
+
+        String expected = "a".repeat(78) + "\r\n  " + "a".repeat(22);
+        assertEquals(expected, out, "Expected wrapping and indenting after 78 chars");
+    }
+
+    @Test
+    void wrapAndIndent_mixedNewlinesAndWraps() throws Exception {
+        BagGenerator bg = Mockito.mock(BagGenerator.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        String base = "This is a line that will be followed by a newline and then a very long line:";
+        String longText = "a".repeat(90);
+        String input = base + "\n" + longText;
+
+        String out = invokeWrapAndIndent(bg, input);
+        String continuation = "\r\n  ";
+
+        assertTrue(out.contains(continuation), "Output should contain CRLF + two space continuation");
+        assertFalse(out.contains("\n") && !out.contains("\r\n"), "Raw LF without CR should not be present");
+
+        // Exact structure: base + CRLF + two spaces + first 76 'a's + CRLF + two spaces + remaining 14 'a's
+        String expected = base + continuation + longText.substring(0, 76) + continuation + longText.substring(76);
+        assertEquals(expected, out);
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
`bag-info.txt` values spanning multiple lines started without indenting after an embedded newline in the value itself, leading to validation errors, as BagIt validators will expect anything starting on a new line without indent to be a new key.

**Which issue(s) this PR closes**: N/a

**Special notes for your reviewer**: N/a

**Suggestions on how to test this**: 
Export a BagPack and make sure that the Description field of your dataset has at least one linefeed character in it. Unzip the resulting BagPack zip file and check that `bag-info.txt`'s `External-Description` field has a properly indented multi-line value.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
N/a

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
N/a

@DANS-KNAW/core-systems 