### PR TITLE
DD-2118, DD-2119 Applying bag exporter and archivalStatus api fixes and improvements to v6.7.1-DANS-DataStation

### DIFF
--- a/doc/release-notes/12063-ORE-and-Bag-updates.md
+++ b/doc/release-notes/12063-ORE-and-Bag-updates.md
@@ -1,0 +1,14 @@
+This release contains multiple updates to the OAI-ORE metadata export and archival Bag output:
+
+OAI-ORE
+- now uses URI for checksum algorithms
+- a bug causing failures with deaccessioned versions when the deaccession note ("Deaccession Reason" in the UI) was null (which has been allowed via the API). 
+- the "https://schema.org/additionalType" is updated to "Dataverse OREMap Format v1.0.2" to indicate that the out has changed 
+
+Archival Bag 
+- for dataset versions with no files, the (empty) manifest-<alg>.txt file created will now use the default algorithm defined by the "FileFixityChecksumAlgorithm" setting rather than always defaulting to "md5"
+- a bug causing the bag-info.txt to not have information on contacts when the dataset version has more than one contact has been fixed
+- values used in the bag-info.txt file that may be multi-line (with embedded CR or LF characters) are now properly indented/formatted per the BagIt specification (i.e. Internal-Sender-Identifier, External-Description, Source-Organization, Organization-Address).
+- the name of the dataset is no longer used as a subdirectory under the data directory (dataset names can be long enough to cause failures when unzipping)
+- a new key, "Dataverse-Bag-Version" has been added to bag-info.txt with a value "1.0", allowing tracking of changes to Dataverse's arhival bag generation
+- improvements to file retrieval w.r.t. retries on errors or throttling

--- a/doc/release-notes/12065-allow-crud-on-archival-status-for-deaccessioned.md
+++ b/doc/release-notes/12065-allow-crud-on-archival-status-for-deaccessioned.md
@@ -1,0 +1,1 @@
+This release removes an undocumented restriction on the API calls to get, set, and delete archival status. They did not work on deaccessioned dataset versions and now do. (See https://guides.dataverse.org/en/latest/api/native-api.html#get-the-archival-status-of-a-dataset-by-version )

--- a/src/main/java/edu/harvard/iq/dataverse/DataFile.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataFile.java
@@ -109,18 +109,22 @@ public class DataFile extends DvObject implements Comparable {
      * The list of types should be limited to the list above in the technote
      * because the string gets passed into MessageDigest.getInstance() and you
      * can't just pass in any old string.
+     * 
+     * The URIs are used in the OAI_ORE export. They are taken from the associated XML Digital Signature standards.
      */
     public enum ChecksumType {
 
-        MD5("MD5"),
-        SHA1("SHA-1"),
-        SHA256("SHA-256"),
-        SHA512("SHA-512");
+        MD5("MD5", "http://www.w3.org/2001/04/xmldsig-more#md5"),
+        SHA1("SHA-1", "http://www.w3.org/2000/09/xmldsig#sha1"),
+        SHA256("SHA-256", "http://www.w3.org/2001/04/xmlenc#sha256"),
+        SHA512("SHA-512", "http://www.w3.org/2001/04/xmlenc#sha512");
 
         private final String text;
+        private final String uri;
 
-        private ChecksumType(final String text) {
+        private ChecksumType(final String text, final String uri) {
             this.text = text;
+            this.uri = uri;
         }
 
         public static ChecksumType fromString(String text) {
@@ -131,12 +135,29 @@ public class DataFile extends DvObject implements Comparable {
                     }
                 }
             }
-            throw new IllegalArgumentException("ChecksumType must be one of these values: " + Arrays.asList(ChecksumType.values()) + ".");
+            throw new IllegalArgumentException(
+                    "ChecksumType must be one of these values: " + Arrays.asList(ChecksumType.values()) + ".");
+        }
+        
+        public static ChecksumType fromUri(String uri) {
+            if (uri != null) {
+                for (ChecksumType checksumType : ChecksumType.values()) {
+                    if (uri.equals(checksumType.uri)) {
+                        return checksumType;
+                    }
+                }
+            }
+            throw new IllegalArgumentException(
+                    "ChecksumType must be one of these values: " + Arrays.asList(ChecksumType.values()) + ".");
         }
 
         @Override
         public String toString() {
             return text;
+        }
+
+        public String toUri() {
+            return uri;
         }
     }
 

--- a/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
+++ b/src/main/java/edu/harvard/iq/dataverse/api/Datasets.java
@@ -5011,7 +5011,7 @@ public class Datasets extends AbstractApiBean {
             }
             DataverseRequest req = createDataverseRequest(au);
             DatasetVersion dsv = getDatasetVersionOrDie(req, versionNumber, findDatasetOrDie(datasetId), uriInfo,
-                    headers);
+                    headers, true);
 
             if (dsv.getArchivalCopyLocation() == null) {
                 return error(Status.NOT_FOUND, "This dataset version has not been archived");
@@ -5053,7 +5053,7 @@ public class Datasets extends AbstractApiBean {
 
                     DataverseRequest req = createDataverseRequest(au);
                     DatasetVersion dsv = getDatasetVersionOrDie(req, versionNumber, findDatasetOrDie(datasetId),
-                            uriInfo, headers);
+                            uriInfo, headers, true);
 
                     if (dsv == null) {
                         return error(Status.NOT_FOUND, "Dataset version not found");
@@ -5100,7 +5100,7 @@ public class Datasets extends AbstractApiBean {
 
             DataverseRequest req = createDataverseRequest(au);
             DatasetVersion dsv = getDatasetVersionOrDie(req, versionNumber, findDatasetOrDie(datasetId), uriInfo,
-                    headers);
+                    headers, true);
             if (dsv == null) {
                 return error(Status.NOT_FOUND, "Dataset version not found");
             }

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -692,6 +692,7 @@ public class SettingsServiceBean {
         PostExternalSearchUrl,
         //Experimental setting to provide a display name for the POST external search service
         PostExternalSearchName,
+        BagGeneratorThreads,
         ;
 
         @Override

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/BagGenerator.java
@@ -4,12 +4,15 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -33,9 +36,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 
-import edu.harvard.iq.dataverse.util.BundleUtil;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.compress.archivers.zip.ParallelScatterZipCreator;
 import org.apache.commons.compress.archivers.zip.ScatterZipOutputStream;
@@ -45,24 +49,24 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.parallel.InputStreamSupplier;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.text.WordUtils;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.util.EntityUtils;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.json.JSONArray;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -75,9 +79,22 @@ import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.DataFile.ChecksumType;
 import edu.harvard.iq.dataverse.pidproviders.PidUtil;
 import edu.harvard.iq.dataverse.settings.JvmSettings;
+import static edu.harvard.iq.dataverse.settings.SettingsServiceBean.Key.BagGeneratorThreads;
+
+import edu.harvard.iq.dataverse.util.SystemConfig;
 import edu.harvard.iq.dataverse.util.json.JsonLDTerm;
+import jakarta.enterprise.inject.spi.CDI;
 import java.util.Optional;
 
+/**
+ * Creates an archival zipped Bag for long-term storage. It is intended to
+ * include all the information needed to reconstruct the dataset version in a
+ * new Dataverse instance.
+ *
+ * Note that the Dataverse-Bag-Version written in the generateInfoFile() method
+ * should be updated any time the content/structure of the bag is changed.
+ *
+ */
 public class BagGenerator {
 
     private static final Logger logger = Logger.getLogger(BagGenerator.class.getCanonicalName());
@@ -91,10 +108,11 @@ public class BagGenerator {
     private HashMap<String, String> pidMap = new LinkedHashMap<String, String>();
     private HashMap<String, String> checksumMap = new LinkedHashMap<String, String>();
 
-    private int timeout = 60;
-    private RequestConfig config = RequestConfig.custom().setConnectTimeout(timeout * 1000)
-            .setConnectionRequestTimeout(timeout * 1000).setSocketTimeout(timeout * 1000)
-            .setCookieSpec(CookieSpecs.STANDARD).build();
+    private int timeout = 300;
+    private RequestConfig config = RequestConfig.custom()
+            .setConnectionRequestTimeout(Timeout.ofSeconds(timeout))
+            .setResponseTimeout(Timeout.ofSeconds(timeout))
+            .build();
     protected CloseableHttpClient client;
     private PoolingHttpClientConnectionManager cm = null;
 
@@ -119,12 +137,31 @@ public class BagGenerator {
 
     private boolean usetemp = false;
 
-    private int numConnections = 8;
-    public static final String BAG_GENERATOR_THREADS = ":BagGeneratorThreads";
+    private static int numConnections = 2;
+    public static final String BAG_GENERATOR_THREADS = BagGeneratorThreads.toString();
 
     private OREMap oremap;
 
     static PrintWriter pw = null;
+
+    // Bag-info.txt field labels
+    private static final String CONTACT_NAME = "Contact-Name: ";
+    private static final String CONTACT_EMAIL = "Contact-Email: ";
+    private static final String SOURCE_ORGANIZATION = "Source-Organization: ";
+    private static final String ORGANIZATION_ADDRESS = "Organization-Address: ";
+    private static final String ORGANIZATION_EMAIL = "Organization-Email: ";
+    private static final String EXTERNAL_DESCRIPTION = "External-Description: ";
+    private static final String BAGGING_DATE = "Bagging-Date: ";
+    private static final String EXTERNAL_IDENTIFIER = "External-Identifier: ";
+    private static final String BAG_SIZE = "Bag-Size: ";
+    private static final String PAYLOAD_OXUM = "Payload-Oxum: ";
+    private static final String INTERNAL_SENDER_IDENTIFIER = "Internal-Sender-Identifier: ";
+    private static final String DATAVERSE_BAG_VERSION = "Dataverse-Bag-Version: ";
+
+ // Implement exponential backoff with jitter
+    static final long baseWaitTimeMs = 1000; // Start with 1 second
+    static final long maxWaitTimeMs = 30000; // Cap at 30 seconds
+
 
     /**
      * This BagGenerator creates a BagIt version 1.0
@@ -138,19 +175,24 @@ public class BagGenerator {
      * and zipping are done in parallel, using a connection pool. The required space
      * on disk is ~ n+1/n of the final bag size, e.g. 125% of the bag size for a
      * 4-way parallel zip operation.
-     * @throws Exception 
-     * @throws JsonSyntaxException 
+     * 
+     * @throws Exception
+     * @throws JsonSyntaxException
      */
 
     public BagGenerator(OREMap oreMap, String dataciteXml) throws JsonSyntaxException, Exception {
         this.oremap = oreMap;
         this.oremapObject = oreMap.getOREMap();
-                //(JsonObject) new JsonParser().parse(oreMap.getOREMap().toString());
         this.dataciteXml = dataciteXml;
 
         try {
-            // Using Dataverse, all the URLs to be retrieved should be on the current server, so allowing self-signed certs and not verifying hostnames are useful in testing and 
-            // shouldn't be a significant security issue. This should not be allowed for arbitrary OREMap sources.
+            /*
+             * Using Dataverse, all the URLs to be retrieved should be on the current
+             * server, so allowing self-signed certs and not verifying hostnames are useful
+             * in testing and shouldn't be a significant security issue. This should not be
+             * allowed for arbitrary OREMap sources.
+             * 
+             */
             SSLContextBuilder builder = new SSLContextBuilder();
             try {
                 builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
@@ -158,21 +200,27 @@ public class BagGenerator {
                 e.printStackTrace();
             }
 
-            SSLConnectionSocketFactory sslConnectionFactory = new SSLConnectionSocketFactory(builder.build(), NoopHostnameVerifier.INSTANCE);
+            SSLConnectionSocketFactory sslConnectionFactory = new SSLConnectionSocketFactory(
+                builder.build(), 
+                NoopHostnameVerifier.INSTANCE
+            );
 
             Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
-            		.register("http", PlainConnectionSocketFactory.getSocketFactory())
+                    .register("http", PlainConnectionSocketFactory.getSocketFactory())
                     .register("https", sslConnectionFactory).build();
             cm = new PoolingHttpClientConnectionManager(registry);
 
             cm.setDefaultMaxPerRoute(numConnections);
             cm.setMaxTotal(numConnections > 20 ? numConnections : 20);
 
-            client = HttpClients.custom().setConnectionManager(cm).setDefaultRequestConfig(config).build();
+            client = HttpClients.custom()
+                    .setConnectionManager(cm)
+                    .setDefaultRequestConfig(config)
+                    .build();
 
             scatterZipCreator = new ParallelScatterZipCreator(Executors.newFixedThreadPool(numConnections));
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
-            logger.warning("Aint gonna work");
+            logger.warning("Failed to initialize HTTP client");
             e.printStackTrace();
         }
     }
@@ -180,11 +228,7 @@ public class BagGenerator {
     public void setIgnoreHashes(boolean val) {
         ignorehashes = val;
     }
-    
-    public void setDefaultCheckSumType(ChecksumType type) {
-    	hashtype=type;
-    }
-    
+
     public static void println(String s) {
         System.out.println(s);
         System.out.flush();
@@ -202,18 +246,18 @@ public class BagGenerator {
      * @return success true/false
      */
     public boolean generateBag(OutputStream outputStream) throws Exception {
-        
 
         File tmp = File.createTempFile("qdr-scatter-dirs", "tmp");
         dirs = ScatterZipOutputStream.fileBased(tmp);
-        // The oremapObject is javax.json.JsonObject and we need com.google.gson.JsonObject for the aggregation object
-        aggregation = (JsonObject) new JsonParser().parse(oremapObject.getJsonObject(JsonLDTerm.ore("describes").getLabel()).toString());
+        // The oremapObject is javax.json.JsonObject and we need
+        // com.google.gson.JsonObject for the aggregation object
+        aggregation = (JsonObject) JsonParser
+                .parseString(oremapObject.getJsonObject(JsonLDTerm.ore("describes").getLabel()).toString());
 
         String pidUrlString = aggregation.get("@id").getAsString();
-        String pidString=PidUtil.parseAsGlobalID(pidUrlString).asString();
-        bagID = pidString + "v."
-                + aggregation.get(JsonLDTerm.schemaOrg("version").getLabel()).getAsString();
-        
+        String pidString = PidUtil.parseAsGlobalID(pidUrlString).asString();
+        bagID = pidString + "v." + aggregation.get(JsonLDTerm.schemaOrg("version").getLabel()).getAsString();
+
         logger.info("Generating Bag: " + bagID);
         try {
             // Create valid filename from identifier and extend path with
@@ -270,6 +314,15 @@ public class BagGenerator {
             String path = sha1Entry.getKey();
             sha1StringBuffer.append(sha1Entry.getValue() + " " + path);
         }
+        if(hashtype == null) { // No files - still want to send an empty manifest to nominally comply with BagIT specification requirement.
+            try {
+                // Use the current type if we can retrieve it
+                hashtype = CDI.current().select(SystemConfig.class).get().getFileFixityChecksumAlgorithm();
+            } catch (Exception e) {
+                // Default to MD5 if we can't
+                hashtype = DataFile.ChecksumType.MD5;
+            }
+        }
         if (!(hashtype == null)) {
             String manifestName = "manifest-";
             if (hashtype.equals(DataFile.ChecksumType.SHA1)) {
@@ -285,7 +338,7 @@ public class BagGenerator {
             }
             createFileFromString(manifestName, sha1StringBuffer.toString());
         } else {
-            logger.warning("No Hash values (no files?) sending empty manifest to nominally comply with BagIT specification requirement");
+            logger.warning("No Hash value defined sending empty manifest-md5 to nominally comply with BagIT specification requirement");
             createFileFromString("manifest-md5.txt", "");
         }
         // bagit.txt - Required by spec
@@ -357,7 +410,6 @@ public class BagGenerator {
 
     public boolean generateBag(String bagName, boolean temp) {
         usetemp = temp;
-        FileOutputStream bagFileOS = null;
         try {
             File origBagFile = getBagFile(bagName);
             File bagFile = origBagFile;
@@ -366,26 +418,25 @@ public class BagGenerator {
                 logger.fine("Writing to: " + bagFile.getAbsolutePath());
             }
             // Create an output stream backed by the file
-            bagFileOS = new FileOutputStream(bagFile);
-            if (generateBag(bagFileOS)) {
-                //The generateBag call sets this.bagName to the correct value
-                validateBagFile(bagFile);
-                if (usetemp) {
-                    logger.fine("Moving tmp zip");
-                    origBagFile.delete();
-                    bagFile.renameTo(origBagFile);
+            try (FileOutputStream bagFileOS = new FileOutputStream(bagFile)) {
+                if (generateBag(bagFileOS)) {
+                    // The generateBag call sets this.bagName to the correct value
+                    validateBagFile(bagFile);
+                    if (usetemp) {
+                        logger.fine("Moving tmp zip");
+                        origBagFile.delete();
+                        bagFile.renameTo(origBagFile);
+                    }
+                    return true;
+                } else {
+                    return false;
                 }
-                return true;
-            } else {
-                return false;
             }
         } catch (Exception e) {
-            logger.log(Level.SEVERE,"Bag Exception: ", e);
+            logger.log(Level.SEVERE, "Bag Exception: ", e);
             e.printStackTrace();
             logger.warning("Failure: Processing failure during Bagit file creation");
             return false;
-        } finally {
-            IOUtils.closeQuietly(bagFileOS);
         }
     }
 
@@ -395,7 +446,7 @@ public class BagGenerator {
         InputStream is = null;
         try {
             File bagFile = getBagFile(bagId);
-            zf = new ZipFile(bagFile);
+            zf = ZipFile.builder().setFile(bagFile).get();
             ZipArchiveEntry entry = zf.getEntry(getValidName(bagId) + "/manifest-sha1.txt");
             if (entry != null) {
                 logger.info("SHA1 hashes used");
@@ -437,9 +488,9 @@ public class BagGenerator {
             logger.info("HashMap Map contains: " + checksumMap.size() + " entries");
             checkFiles(checksumMap, bagFile);
         } catch (IOException io) {
-            logger.log(Level.SEVERE,"Could not validate Hashes", io);
+            logger.log(Level.SEVERE, "Could not validate Hashes", io);
         } catch (Exception e) {
-            logger.log(Level.SEVERE,"Could not validate Hashes", e);
+            logger.log(Level.SEVERE, "Could not validate Hashes", e);
         } finally {
             IOUtils.closeQuietly(zf);
         }
@@ -464,7 +515,7 @@ public class BagGenerator {
 
     private void validateBagFile(File bagFile) throws IOException {
         // Run a confirmation test - should verify all files and hashes
-        
+
         // Check files calculates the hashes and file sizes and reports on
         // whether hashes are correct
         checkFiles(checksumMap, bagFile);
@@ -481,14 +532,6 @@ public class BagGenerator {
     private void processContainer(JsonObject item, String currentPath) throws IOException {
         JsonArray children = getChildren(item);
         HashSet<String> titles = new HashSet<String>();
-        String title = null;
-        if (item.has(JsonLDTerm.dcTerms("Title").getLabel())) {
-            title = item.get("Title").getAsString();
-        } else if (item.has(JsonLDTerm.schemaOrg("name").getLabel())) {
-            title = item.get(JsonLDTerm.schemaOrg("name").getLabel()).getAsString();
-        }
-        logger.fine("Adding " + title + "/ to path " + currentPath);
-        currentPath = currentPath + title + "/";
         int containerIndex = -1;
         try {
             createDir(currentPath);
@@ -540,28 +583,27 @@ public class BagGenerator {
                 }
                 String childPath = currentPath + childTitle;
                 JsonElement directoryLabel = child.get(JsonLDTerm.DVCore("directoryLabel").getLabel());
-                if(directoryLabel!=null) {
-                    childPath=currentPath + directoryLabel.getAsString() + "/" + childTitle;
+                if (directoryLabel != null) {
+                    childPath = currentPath + directoryLabel.getAsString() + "/" + childTitle;
                 }
-                
 
                 String childHash = null;
                 if (child.has(JsonLDTerm.checksum.getLabel())) {
-                    ChecksumType childHashType = ChecksumType.fromString(
-                            child.getAsJsonObject(JsonLDTerm.checksum.getLabel()).get("@type").getAsString());
+                    ChecksumType childHashType = ChecksumType
+                            .fromUri(child.getAsJsonObject(JsonLDTerm.checksum.getLabel()).get("@type").getAsString());
                     if (hashtype == null) {
-                    	//If one wasn't set as a default, pick up what the first child with one uses
+                        // If one wasn't set as a default, pick up what the first child with one uses
                         hashtype = childHashType;
                     }
                     if (hashtype != null && !hashtype.equals(childHashType)) {
                         logger.warning("Multiple hash values in use - will calculate " + hashtype.toString()
-                            + " hashes for " + childTitle);
+                                + " hashes for " + childTitle);
                     } else {
                         childHash = child.getAsJsonObject(JsonLDTerm.checksum.getLabel()).get("@value").getAsString();
                         if (checksumMap.containsValue(childHash)) {
                             // Something else has this hash
                             logger.warning("Duplicate/Collision: " + child.get("@id").getAsString() + " has SHA1 Hash: "
-                                + childHash + " in: " + bagID);
+                                    + childHash + " in: " + bagID);
                         }
                         logger.fine("Adding " + childPath + " with hash " + childHash + " to checksumMap");
                         checksumMap.put(childPath, childHash);
@@ -574,9 +616,7 @@ public class BagGenerator {
                 try {
                     if ((childHash == null) | ignorehashes) {
                         // Generate missing hashInputStream inputStream = null;
-                        InputStream inputStream = null;
-                        try {
-                            inputStream = getInputStreamSupplier(dataUrl).get();
+                        try (InputStream inputStream = getInputStreamSupplier(dataUrl).get()) {
 
                             if (hashtype != null) {
                                 if (hashtype.equals(DataFile.ChecksumType.SHA1)) {
@@ -593,8 +633,6 @@ public class BagGenerator {
                         } catch (IOException e) {
                             logger.severe("Failed to read " + childPath);
                             throw e;
-                        } finally {
-                            IOUtils.closeQuietly(inputStream);
                         }
                         if (childHash != null) {
                             JsonObject childHashObject = new JsonObject();
@@ -704,9 +742,7 @@ public class BagGenerator {
 
     private void checkFiles(HashMap<String, String> shaMap, File bagFile) {
         ExecutorService executor = Executors.newFixedThreadPool(numConnections);
-        ZipFile zf = null;
-        try {
-            zf = new ZipFile(bagFile);
+        try (ZipFile zf = ZipFile.builder().setFile(bagFile).get()) {
 
             BagValidationJob.setZipFile(zf);
             BagValidationJob.setBagGenerator(this);
@@ -729,12 +765,9 @@ public class BagGenerator {
                 }
             } catch (InterruptedException e) {
                 logger.log(Level.SEVERE, "Hash Calculations interrupted", e);
-            } 
+            }
         } catch (IOException e1) {
-            // TODO Auto-generated catch block
             e1.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(zf);
         }
         logger.fine("Hash Validations Completed");
 
@@ -763,53 +796,51 @@ public class BagGenerator {
         logger.fine("Generating info file");
         StringBuffer info = new StringBuffer();
 
-        JsonArray contactsArray = new JsonArray();
-        /* Contact, and it's subfields, are terms from citation.tsv whose mapping to a formal vocabulary and label in the oremap may change
-         * so we need to find the labels used.
-         */ 
+        /*
+         * Contact, and it's subfields, are terms from citation.tsv whose mapping to a
+         * formal vocabulary and label in the oremap may change so we need to find the
+         * labels used.
+         */
         JsonLDTerm contactTerm = oremap.getContactTerm();
         if ((contactTerm != null) && aggregation.has(contactTerm.getLabel())) {
 
             JsonElement contacts = aggregation.get(contactTerm.getLabel());
             JsonLDTerm contactNameTerm = oremap.getContactNameTerm();
             JsonLDTerm contactEmailTerm = oremap.getContactEmailTerm();
-            
+
             if (contacts.isJsonArray()) {
+                JsonArray contactsArray = contacts.getAsJsonArray();
                 for (int i = 0; i < contactsArray.size(); i++) {
-                    info.append("Contact-Name: ");
+                    
                     JsonElement person = contactsArray.get(i);
                     if (person.isJsonPrimitive()) {
-                        info.append(person.getAsString());
+                        info.append(multilineWrap(CONTACT_NAME + person.getAsString()));
                         info.append(CRLF);
 
                     } else {
-                        if(contactNameTerm != null) {
-                          info.append(((JsonObject) person).get(contactNameTerm.getLabel()).getAsString());
-                          info.append(CRLF);
+                        if (contactNameTerm != null) {
+                            info.append(multilineWrap(CONTACT_NAME + ((JsonObject) person).get(contactNameTerm.getLabel()).getAsString()));
+                            info.append(CRLF);
                         }
-                        if ((contactEmailTerm!=null) &&((JsonObject) person).has(contactEmailTerm.getLabel())) {
-                            info.append("Contact-Email: ");
-                            info.append(((JsonObject) person).get(contactEmailTerm.getLabel()).getAsString());
+                        if ((contactEmailTerm != null) && ((JsonObject) person).has(contactEmailTerm.getLabel())) {
+                            info.append(multilineWrap(CONTACT_EMAIL + ((JsonObject) person).get(contactEmailTerm.getLabel()).getAsString()));
                             info.append(CRLF);
                         }
                     }
                 }
             } else {
-                info.append("Contact-Name: ");
-
                 if (contacts.isJsonPrimitive()) {
-                    info.append((String) contacts.getAsString());
+                    info.append(multilineWrap(CONTACT_NAME + (String) contacts.getAsString()));
                     info.append(CRLF);
 
                 } else {
                     JsonObject person = contacts.getAsJsonObject();
-                    if(contactNameTerm != null) {
-                      info.append(person.get(contactNameTerm.getLabel()).getAsString());
-                      info.append(CRLF);
+                    if (contactNameTerm != null) {
+                        info.append(multilineWrap(CONTACT_NAME + person.get(contactNameTerm.getLabel()).getAsString()));
+                        info.append(CRLF);
                     }
-                    if ((contactEmailTerm!=null) && (person.has(contactEmailTerm.getLabel()))) {
-                        info.append("Contact-Email: ");
-                        info.append(person.get(contactEmailTerm.getLabel()).getAsString());
+                    if ((contactEmailTerm != null) && (person.has(contactEmailTerm.getLabel()))) {
+                        info.append(multilineWrap(CONTACT_EMAIL + person.get(contactEmailTerm.getLabel()).getAsString()));
                         info.append(CRLF);
                     }
                 }
@@ -819,88 +850,222 @@ public class BagGenerator {
             logger.warning("No contact info available for BagIt Info file");
         }
 
-        String orgName = JvmSettings.BAGIT_SOURCE_ORG_NAME.lookupOptional(String.class).orElse("Dataverse Installation (<Site Url>)");
+        String orgName = JvmSettings.BAGIT_SOURCE_ORG_NAME.lookupOptional(String.class)
+                .orElse("Dataverse Installation (<Site Url>)");
         String orgAddress = JvmSettings.BAGIT_SOURCEORG_ADDRESS.lookupOptional(String.class).orElse("<Full address>");
         String orgEmail = JvmSettings.BAGIT_SOURCEORG_EMAIL.lookupOptional(String.class).orElse("<Email address>");
 
-        info.append("Source-Organization: " + orgName);
+        info.append(multilineWrap(SOURCE_ORGANIZATION + orgName));
         // ToDo - make configurable
         info.append(CRLF);
 
-        info.append("Organization-Address: " + WordUtils.wrap(orgAddress, 78, CRLF + " ", true));
+        info.append(multilineWrap(ORGANIZATION_ADDRESS + orgAddress));
 
         info.append(CRLF);
 
         // Not a BagIt standard name
-        info.append("Organization-Email: " + orgEmail);
+        info.append(multilineWrap(ORGANIZATION_EMAIL + orgEmail));
         info.append(CRLF);
 
-        info.append("External-Description: ");
-        
-        /* Description, and it's subfields, are terms from citation.tsv whose mapping to a formal vocabulary and label in the oremap may change
-         * so we need to find the labels used.
+        /*
+         * Description, and it's subfields, are terms from citation.tsv whose mapping to
+         * a formal vocabulary and label in the oremap may change so we need to find the
+         * labels used.
          */
         JsonLDTerm descriptionTerm = oremap.getDescriptionTerm();
         JsonLDTerm descriptionTextTerm = oremap.getDescriptionTextTerm();
         if (descriptionTerm == null) {
             logger.warning("No description available for BagIt Info file");
         } else {
-            info.append(
-                    // FixMe - handle description having subfields better
-                    WordUtils.wrap(getSingleValue(aggregation.get(descriptionTerm.getLabel()),
-                            descriptionTextTerm.getLabel()), 78, CRLF + " ", true));
+            info.append(multilineWrap(EXTERNAL_DESCRIPTION
+                    + getSingleValue(aggregation.get(descriptionTerm.getLabel()), descriptionTextTerm.getLabel())));
 
             info.append(CRLF);
         }
-        info.append("Bagging-Date: ");
+        info.append(BAGGING_DATE);
         info.append((new SimpleDateFormat("yyyy-MM-dd").format(Calendar.getInstance().getTime())));
         info.append(CRLF);
 
-        info.append("External-Identifier: ");
-        info.append(aggregation.get("@id").getAsString());
+        info.append(multilineWrap(EXTERNAL_IDENTIFIER + aggregation.get("@id").getAsString()));
         info.append(CRLF);
 
-        info.append("Bag-Size: ");
+        info.append(BAG_SIZE);
         info.append(byteCountToDisplaySize(totalDataSize));
         info.append(CRLF);
 
-        info.append("Payload-Oxum: ");
+        info.append(PAYLOAD_OXUM);
         info.append(Long.toString(totalDataSize));
         info.append(".");
         info.append(Long.toString(dataCount));
         info.append(CRLF);
 
-        info.append("Internal-Sender-Identifier: ");
         String catalog = orgName + " Catalog";
         if (aggregation.has(JsonLDTerm.schemaOrg("includedInDataCatalog").getLabel())) {
             catalog = aggregation.get(JsonLDTerm.schemaOrg("includedInDataCatalog").getLabel()).getAsString();
         }
-        info.append(catalog + ":" + aggregation.get(JsonLDTerm.schemaOrg("name").getLabel()).getAsString());
+        info.append(multilineWrap(INTERNAL_SENDER_IDENTIFIER + catalog + ":"
+                + aggregation.get(JsonLDTerm.schemaOrg("name").getLabel()).getAsString()));
         info.append(CRLF);
 
+        // Add a version number for our bag type - should be updated with any change to
+        // the bag content/structure
+        info.append(DATAVERSE_BAG_VERSION + "1.0");
+        info.append(CRLF);
         return info.toString();
 
     }
 
+    static private String multilineWrap(String value) {
+        // Normalize line breaks and ensure all lines after the first are indented
+        String[] lines = value.split("\\r?\\n");
+        StringBuilder wrappedValue = new StringBuilder();
+        for (int i = 0; i < lines.length; i++) {
+            // Skip empty lines - RFC8493 (section 7.3) doesn't allow truly empty lines,
+            // While trailing whitespace or whitespace-only lines appear to be allowed, it's
+            // not clear that handling them adds value (visually identical entries in
+            // Dataverse could result in entries w/ or w/o extra lines in the bag-info.txt
+            // file
+            String line = lines[i].trim();
+            if (line.length() > 0) {
+                // Recommended line length, including the label or indents is 79
+                String wrapped = lineWrap(line, 79, CRLF + " ", true);
+                wrappedValue.append(wrapped);
+                if (i < lines.length - 1) {
+                    wrappedValue.append(CRLF).append(" ");
+                }
+            }
+        }
+        return wrappedValue.toString();
+    }
+
+    /** Adapted from Apache WordUtils.wrap() - make subsequent lines shorter by the length of any spaces in newLineStr*/
+    public static String lineWrap(final String str, int wrapLength, String newLineStr, final boolean wrapLongWords) {
+        if (str == null) {
+            return null;
+        }
+        if (newLineStr == null) {
+            newLineStr = System.lineSeparator();
+        }
+        if (wrapLength < 1) {
+            wrapLength = 1;
+        }
+
+        // Calculate the indent length (characters after CRLF in newLineStr)
+        int indentLength = 0;
+        int crlfIndex = newLineStr.lastIndexOf("\n");
+        if (crlfIndex != -1) {
+            indentLength = newLineStr.length() - crlfIndex -1;
+        }
+
+        String wrapOn = " ";
+        final Pattern patternToWrapOn = Pattern.compile(wrapOn);
+        final int inputLineLength = str.length();
+        int offset = 0;
+        final StringBuilder wrappedLine = new StringBuilder(inputLineLength + 32);
+        int matcherSize = -1;
+        boolean isFirstLine = true;
+
+        while (offset < inputLineLength) {
+            // Adjust wrap length based on whether this is the first line or subsequent
+            // lines
+            int currentWrapLength = isFirstLine ? wrapLength : (wrapLength - indentLength);
+
+            int spaceToWrapAt = -1;
+            Matcher matcher = patternToWrapOn.matcher(str.substring(offset,
+                    Math.min((int) Math.min(Integer.MAX_VALUE, offset + currentWrapLength + 1L), inputLineLength)));
+            if (matcher.find()) {
+                if (matcher.start() == 0) {
+                    matcherSize = matcher.end();
+                    if (matcherSize != 0) {
+                        offset += matcher.end();
+                        continue;
+                    }
+                    offset += 1;
+                }
+                spaceToWrapAt = matcher.start() + offset;
+            }
+
+            // only last line without leading spaces is left
+            if (inputLineLength - offset <= currentWrapLength) {
+                break;
+            }
+
+            while (matcher.find()) {
+                spaceToWrapAt = matcher.start() + offset;
+            }
+
+            if (spaceToWrapAt >= offset) {
+                // normal case
+                wrappedLine.append(str, offset, spaceToWrapAt);
+                wrappedLine.append(newLineStr);
+                offset = spaceToWrapAt + 1;
+                isFirstLine = false;
+
+            } else // really long word or URL
+            if (wrapLongWords) {
+                if (matcherSize == 0) {
+                    offset--;
+                }
+                // wrap really long word one line at a time
+                wrappedLine.append(str, offset, currentWrapLength + offset);
+                wrappedLine.append(newLineStr);
+                offset += currentWrapLength;
+                matcherSize = -1;
+                isFirstLine = false;
+            } else {
+                // do not wrap really long word, just extend beyond limit
+                matcher = patternToWrapOn.matcher(str.substring(offset + currentWrapLength));
+                if (matcher.find()) {
+                    matcherSize = matcher.end() - matcher.start();
+                    spaceToWrapAt = matcher.start() + offset + currentWrapLength;
+                }
+
+                if (spaceToWrapAt >= 0) {
+                    if (matcherSize == 0 && offset != 0) {
+                        offset--;
+                    }
+                    wrappedLine.append(str, offset, spaceToWrapAt);
+                    wrappedLine.append(newLineStr);
+                    offset = spaceToWrapAt + 1;
+                    isFirstLine = false;
+                } else {
+                    if (matcherSize == 0 && offset != 0) {
+                        offset--;
+                    }
+                    wrappedLine.append(str, offset, str.length());
+                    offset = inputLineLength;
+                    matcherSize = -1;
+                }
+            }
+        }
+
+        if (matcherSize == 0 && offset < inputLineLength) {
+            offset--;
+        }
+
+        // Whatever is left in line is short enough to just pass through
+        wrappedLine.append(str, offset, str.length());
+
+        return wrappedLine.toString();
+    }
+
     /**
-     * Kludge - compound values (e.g. for descriptions) are sent as an array of
+     * Compound values (e.g. for descriptions) are sent as an array of
      * objects containing key/values whereas a single value is sent as one object.
      * For cases where multiple values are sent, create a concatenated string so
      * that information is not lost.
      * 
-     * @param jsonElement
-     *            - the root json object
-     * @param key
-     *            - the key to find a value(s) for
+     * @param jsonElement - the root json object
+     * @param key         - the key to find a value(s) for
      * @return - a single string
      */
     String getSingleValue(JsonElement jsonElement, String key) {
         String val = "";
-        if(jsonElement.isJsonObject()) {
-            JsonObject jsonObject=jsonElement.getAsJsonObject();
+        if (jsonElement.isJsonObject()) {
+            JsonObject jsonObject = jsonElement.getAsJsonObject();
             val = jsonObject.get(key).getAsString();
         } else if (jsonElement.isJsonArray()) {
-            
+
             Iterator<JsonElement> iter = jsonElement.getAsJsonArray().iterator();
             ArrayList<String> stringArray = new ArrayList<String>();
             while (iter.hasNext()) {
@@ -993,10 +1158,8 @@ public class BagGenerator {
                 urlString = urlString + ((urlString.indexOf('?') != -1) ? "&key=" : "?key=") + apiKey;
                 request = new HttpGet(new URI(urlString));
             } catch (MalformedURLException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             } catch (URISyntaxException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
         } else {
@@ -1008,6 +1171,10 @@ public class BagGenerator {
         return request;
     }
 
+    /** Get a stream supplier for the given URI.
+     * 
+     *  Caller must close the stream when done.
+     */
     InputStreamSupplier getInputStreamSupplier(final String uriString) {
 
         return new InputStreamSupplier() {
@@ -1020,58 +1187,88 @@ public class BagGenerator {
 
                         logger.fine("Get # " + tries + " for " + uriString);
                         HttpGet getFile = createNewGetRequest(uri, null);
-                        logger.finest("Retrieving " + tries + ": " + uriString);
-                        CloseableHttpResponse response = null;
+
                         try {
-                            response = client.execute(getFile);
-                            // Note - if we ever need to pass an HttpClientContext, we need a new one per
-                            // thread.
-                            int statusCode = response.getStatusLine().getStatusCode();
+                            // Execute the request directly and keep the response open
+                            final CloseableHttpResponse response = (CloseableHttpResponse) client.executeOpen(null, getFile, HttpClientContext.create());
+                            int statusCode = response.getCode();
+
                             if (statusCode == 200) {
                                 logger.finest("Retrieved: " + uri);
-                                return response.getEntity().getContent();
-                            }
-                            logger.warning("Attempt: " + tries + " - Unexpected Status when retrieving " + uriString
-                                    + " : " + statusCode);
-                            if (statusCode < 500) {
-                                logger.fine("Will not retry for 40x errors");
-                                tries += 5;
-                            } else {
-                                tries++;
-                            }
-                            // Error handling
-                            if (response != null) {
-                                try {
-                                    EntityUtils.consumeQuietly(response.getEntity());
+                                // Return a wrapped stream that will close the response when the stream is closed
+                                final HttpEntity entity = response.getEntity();
+                                if (entity != null) {
+                                    // Create a wrapper stream that closes the response when the stream is closed
+                                    return new FilterInputStream(entity.getContent()) {
+                                        @Override
+                                        public void close() throws IOException {
+                                            try {
+                                                super.close();
+                                            } finally {
+                                                response.close();
+                                            }
+                                        }
+                                    };
+                                } else {
                                     response.close();
-                                } catch (IOException io) {
-                                    logger.warning(
-                                            "Exception closing response after status: " + statusCode + " on " + uri);
+                                    logger.warning("No content in response for: " + uriString);
+                                    return null;
+                                }
+                            } else {
+                                // Close the response for non-200 responses
+                                response.close();
+
+                                logger.warning("Attempt: " + tries + " - Unexpected Status when retrieving " + uriString
+                                        + " : " + statusCode);
+                                tries++;
+                                try {
+                                    // Calculate exponential backoff: 2^tries * baseWaitTimeMs (1 sec)
+                                    long waitTime = (long) (Math.pow(2, tries) * baseWaitTimeMs);
+
+                                    // Add jitter: random value between 0-30% of the wait time
+                                    long jitter = (long) (waitTime * 0.3 * Math.random());
+                                    waitTime = waitTime + jitter;
+
+                                    // Cap the wait time at maxWaitTimeMs (30 seconds)
+                                    waitTime = Math.min(waitTime, maxWaitTimeMs);
+
+                                    logger.fine("Sleeping for " + waitTime + "ms before retry attempt " + tries);
+                                    Thread.sleep(waitTime);
+                                } catch (InterruptedException ie) {
+                                    logger.log(Level.SEVERE, "InterruptedException during retry delay for file: " + uriString, ie);
+                                    Thread.currentThread().interrupt(); // Restore interrupt status
+                                    tries += 5; // Skip remaining attempts
                                 }
                             }
                         } catch (ClientProtocolException e) {
                             tries += 5;
-                            // TODO Auto-generated catch block
-                            e.printStackTrace();
-                        } catch (IOException e) {
-                            // Retry if this is a potentially temporary error such
-                            // as a timeout
+                            logger.log(Level.SEVERE, "ClientProtocolException when retrieving file: " + uriString + " (attempt " + tries + ")", e);
+                        } catch (SocketTimeoutException e) {
+                            // Specific handling for timeout exceptions
                             tries++;
-                            logger.log(Level.WARNING, "Attempt# " + tries + " : Unable to retrieve file: " + uriString,
-                                    e);
+                            logger.log(Level.SEVERE, "SocketTimeoutException when retrieving file: " + uriString + " (attempt " + tries + " of 5) - Request exceeded timeout", e);
                             if (tries == 5) {
-                                logger.severe("Final attempt failed for " + uriString);
+                                logger.log(Level.SEVERE, "FINAL FAILURE: File could not be retrieved after all retries due to timeouts: " + uriString, e);
                             }
-                            e.printStackTrace();
+                        } catch (InterruptedIOException e) {
+                            // Catches interruptions during I/O operations
+                            tries += 5;
+                            logger.log(Level.SEVERE, "InterruptedIOException when retrieving file: " + uriString + " - Operation was interrupted", e);
+                            Thread.currentThread().interrupt(); // Restore interrupt status
+                        } catch (IOException e) {
+                            // Retry if this is a potentially temporary error such as a timeout
+                            tries++;
+                            logger.log(Level.WARNING, "IOException when retrieving file: " + uriString + " (attempt " + tries + " of 5)", e);
+                            if (tries == 5) {
+                                logger.log(Level.SEVERE, "FINAL FAILURE: File could not be retrieved after all retries: " + uriString, e);
+                            }
                         }
 
                     }
-
                 } catch (URISyntaxException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    logger.log(Level.SEVERE, "URISyntaxException for file: " + uriString + " - Invalid URI format", e);
                 }
-                logger.severe("Could not read: " + uriString);
+                logger.severe("FAILED TO RETRIEVE FILE after all retries: " + uriString);
                 return null;
             }
         };
@@ -1100,8 +1297,7 @@ public class BagGenerator {
      * Returns a human-readable version of the file size, where the input represents
      * a specific number of bytes.
      *
-     * @param size
-     *            the number of bytes
+     * @param size the number of bytes
      * @return a human-readable display value (includes units)
      */
     public static String byteCountToDisplaySize(long size) {
@@ -1123,9 +1319,9 @@ public class BagGenerator {
         apiKey = tokenString;
     }
 
-    public void setNumConnections(int numConnections) {
-        this.numConnections = numConnections;
-        logger.fine("BagGenerator will use " + numConnections + " threads");
+    public static void setNumConnections(int numConnections) {
+        BagGenerator.numConnections = numConnections;
+        logger.fine("All BagGenerators will use " + numConnections + " threads");
     }
 
 }

--- a/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/bagit/OREMap.java
@@ -49,7 +49,7 @@ public class OREMap {
     public static final String NAME = "OREMap";
     
     //NOTE: Update this value whenever the output of this class is changed
-    private static final String DATAVERSE_ORE_FORMAT_VERSION = "Dataverse OREMap Format v1.0.1";
+    private static final String DATAVERSE_ORE_FORMAT_VERSION = "Dataverse OREMap Format v1.0.2";
     //v1.0.1 - added versionNote
     private static final String DATAVERSE_SOFTWARE_NAME = "Dataverse";
     private static final String DATAVERSE_SOFTWARE_URL = "https://github.com/iqss/dataverse";
@@ -130,7 +130,8 @@ public class OREMap {
         if(vs.equals(VersionState.DEACCESSIONED)) {
             JsonObjectBuilder deaccBuilder = Json.createObjectBuilder();
             deaccBuilder.add(JsonLDTerm.schemaOrg("name").getLabel(), vs.name());
-            deaccBuilder.add(JsonLDTerm.DVCore("reason").getLabel(), version.getDeaccessionNote());
+            // Reason is supposed to not be null, but historically this has not been enforced (in the API)
+            addIfNotNull(deaccBuilder, JsonLDTerm.DVCore("reason"), version.getDeaccessionNote());
             addIfNotNull(deaccBuilder, JsonLDTerm.DVCore("forwardUrl"), version.getDeaccessionLink());
             aggBuilder.add(JsonLDTerm.schemaOrg("creativeWorkStatus").getLabel(), deaccBuilder);
             
@@ -280,7 +281,7 @@ public class OREMap {
                 JsonObject checksum = null;
                 // Add checksum. RDA recommends SHA-512
                 if (df.getChecksumType() != null && df.getChecksumValue() != null) {
-                    checksum = Json.createObjectBuilder().add("@type", df.getChecksumType().toString())
+                    checksum = Json.createObjectBuilder().add("@type", df.getChecksumType().toUri())
                             .add("@value", df.getChecksumValue()).build();
                     aggRes.add(JsonLDTerm.checksum.getLabel(), checksum);
                 }

--- a/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagGeneratorInfoFileTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagGeneratorInfoFileTest.java
@@ -1,0 +1,295 @@
+
+package edu.harvard.iq.dataverse.util.bagit;
+
+import edu.harvard.iq.dataverse.util.json.JsonLDTerm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.gson.JsonParser;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class BagGeneratorInfoFileTest {
+
+    private BagGenerator bagGenerator;
+    private JsonObjectBuilder testAggregationBuilder;
+    
+    @Mock
+    private OREMap mockOreMap;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        
+        // Create base test aggregation builder with required fields
+        testAggregationBuilder = Json.createObjectBuilder();
+        testAggregationBuilder.add("@id", "doi:10.5072/FK2/TEST123");
+        testAggregationBuilder.add(JsonLDTerm.schemaOrg("name").getLabel(), "Test Dataset");
+        testAggregationBuilder.add(JsonLDTerm.schemaOrg("includedInDataCatalog").getLabel(), "Test Catalog");
+    }
+
+    /**
+     * Helper method to finalize the aggregation and create the BagGenerator
+     */
+    private void initializeBagGenerator() throws Exception {
+        JsonObject testAggregation = testAggregationBuilder.build();
+        
+        JsonObjectBuilder oremapJsonBuilder = Json.createObjectBuilder();
+        oremapJsonBuilder.add(JsonLDTerm.ore("describes").getLabel(), testAggregation);
+        JsonObject oremapObject = oremapJsonBuilder.build();
+        // Mock the OREMap.getOREMap() method to return the built JSON
+        when(mockOreMap.getOREMap()).thenReturn(oremapObject);
+        
+        // Initialize BagGenerator with test data
+        bagGenerator = new BagGenerator(mockOreMap, "");
+        setPrivateField(bagGenerator, "aggregation", (com.google.gson.JsonObject) JsonParser
+                .parseString(oremapObject.getJsonObject(JsonLDTerm.ore("describes").getLabel()).toString()));
+        setPrivateField(bagGenerator, "totalDataSize", 1024000L);
+        setPrivateField(bagGenerator, "dataCount", 10L);
+    }
+
+    @Test
+    public void testGenerateInfoFileWithSingleContact() throws Exception {
+        // Arrange
+        JsonLDTerm contactTerm = JsonLDTerm.schemaOrg("creator");
+        JsonLDTerm contactNameTerm = JsonLDTerm.schemaOrg("name");
+        JsonLDTerm contactEmailTerm = JsonLDTerm.schemaOrg("email");
+        
+        when(mockOreMap.getContactTerm()).thenReturn(contactTerm);
+        when(mockOreMap.getContactNameTerm()).thenReturn(contactNameTerm);
+        when(mockOreMap.getContactEmailTerm()).thenReturn(contactEmailTerm);
+
+        JsonObjectBuilder contactBuilder = Json.createObjectBuilder();
+        contactBuilder.add(contactNameTerm.getLabel(), "John Doe");
+        contactBuilder.add(contactEmailTerm.getLabel(), "john.doe@example.com");
+        testAggregationBuilder.add(contactTerm.getLabel(), contactBuilder);
+
+        initializeBagGenerator();
+
+        // Act
+        String infoFile = invokeGenerateInfoFile();
+
+        // Assert
+        assertNotNull(infoFile);
+        assertTrue(infoFile.contains("Contact-Name: John Doe"));
+        assertTrue(infoFile.contains("Contact-Email: john.doe@example.com"));
+    }
+
+    @Test
+    public void testGenerateInfoFileWithMultipleContacts() throws Exception {
+        // Arrange
+        JsonLDTerm contactTerm = JsonLDTerm.schemaOrg("creator");
+        JsonLDTerm contactNameTerm = JsonLDTerm.schemaOrg("name");
+        JsonLDTerm contactEmailTerm = JsonLDTerm.schemaOrg("email");
+        
+        when(mockOreMap.getContactTerm()).thenReturn(contactTerm);
+        when(mockOreMap.getContactNameTerm()).thenReturn(contactNameTerm);
+        when(mockOreMap.getContactEmailTerm()).thenReturn(contactEmailTerm);
+
+        JsonArrayBuilder contactsBuilder = Json.createArrayBuilder();
+        
+        JsonObjectBuilder contact1 = Json.createObjectBuilder();
+        contact1.add(contactNameTerm.getLabel(), "John Doe");
+        contact1.add(contactEmailTerm.getLabel(), "john.doe@example.com");
+        
+        JsonObjectBuilder contact2 = Json.createObjectBuilder();
+        contact2.add(contactNameTerm.getLabel(), "Jane Smith");
+        contact2.add(contactEmailTerm.getLabel(), "jane.smith@example.com");
+        
+        JsonObjectBuilder contact3 = Json.createObjectBuilder();
+        contact3.add(contactNameTerm.getLabel(), "Bob Johnson");
+        contact3.add(contactEmailTerm.getLabel(), "bob.johnson@example.com");
+        
+        contactsBuilder.add(contact1);
+        contactsBuilder.add(contact2);
+        contactsBuilder.add(contact3);
+
+        testAggregationBuilder.add(contactTerm.getLabel(), contactsBuilder);
+
+        initializeBagGenerator();
+
+        // Act
+        String infoFile = invokeGenerateInfoFile();
+
+        // Assert
+        assertNotNull(infoFile);
+        assertTrue(infoFile.contains("Contact-Name: John Doe"));
+        assertTrue(infoFile.contains("Contact-Email: john.doe@example.com"));
+        assertTrue(infoFile.contains("Contact-Name: Jane Smith"));
+        assertTrue(infoFile.contains("Contact-Email: jane.smith@example.com"));
+        assertTrue(infoFile.contains("Contact-Name: Bob Johnson"));
+        assertTrue(infoFile.contains("Contact-Email: bob.johnson@example.com"));
+    }
+
+    @Test
+    public void testGenerateInfoFileWithSingleDescription() throws Exception {
+        // Arrange
+        JsonLDTerm descriptionTerm = JsonLDTerm.schemaOrg("description");
+        JsonLDTerm descriptionTextTerm = JsonLDTerm.schemaOrg("value");
+        
+        when(mockOreMap.getDescriptionTerm()).thenReturn(descriptionTerm);
+        when(mockOreMap.getDescriptionTextTerm()).thenReturn(descriptionTextTerm);
+
+        JsonObjectBuilder descriptionBuilder = Json.createObjectBuilder();
+        descriptionBuilder.add(descriptionTextTerm.getLabel(), "This is a test dataset description.");
+        testAggregationBuilder.add(descriptionTerm.getLabel(), descriptionBuilder);
+
+        initializeBagGenerator();
+
+        // Act
+        String infoFile = invokeGenerateInfoFile();
+
+        // Assert
+        assertNotNull(infoFile);
+        assertTrue(infoFile.contains("External-Description: This is a test dataset description."));
+    }
+
+     @Test
+    public void testGenerateInfoFileWithMultipleDescriptions() throws Exception {
+        // Arrange
+        JsonLDTerm descriptionTerm = JsonLDTerm.schemaOrg("description");
+        JsonLDTerm descriptionTextTerm = JsonLDTerm.schemaOrg("value");
+        
+        when(mockOreMap.getDescriptionTerm()).thenReturn(descriptionTerm);
+        when(mockOreMap.getDescriptionTextTerm()).thenReturn(descriptionTextTerm);
+
+        JsonArrayBuilder descriptionsBuilder = Json.createArrayBuilder();
+        
+        JsonObjectBuilder desc1 = Json.createObjectBuilder();
+        desc1.add(descriptionTextTerm.getLabel(), "First description of the dataset.");
+        
+        JsonObjectBuilder desc2 = Json.createObjectBuilder();
+        desc2.add(descriptionTextTerm.getLabel(), "Second description with additional details.");
+        
+        JsonObjectBuilder desc3 = Json.createObjectBuilder();
+        desc3.add(descriptionTextTerm.getLabel(), "Third description for completeness.");
+        
+        descriptionsBuilder.add(desc1);
+        descriptionsBuilder.add(desc2);
+        descriptionsBuilder.add(desc3);
+
+        testAggregationBuilder.add(descriptionTerm.getLabel(), descriptionsBuilder);
+
+        initializeBagGenerator();
+
+        // Act
+        String infoFile = invokeGenerateInfoFile();
+        // Assert
+        assertNotNull(infoFile);
+        // Multiple descriptions should be concatenated with commas as per getSingleValue method
+        assertTrue(infoFile.contains("External-Description: First description of the dataset.,Second description with\r\n additional details.,Third description for completeness."));
+    }
+
+    @Test
+    public void testGenerateInfoFileWithRequiredFields() throws Exception {
+        // Arrange - minimal setup with required fields already in setUp()
+        JsonLDTerm contactTerm = JsonLDTerm.schemaOrg("creator");
+        JsonLDTerm contactNameTerm = JsonLDTerm.schemaOrg("name");
+        JsonLDTerm descriptionTerm = JsonLDTerm.schemaOrg("description");
+        JsonLDTerm descriptionTextTerm = JsonLDTerm.schemaOrg("value");
+        
+        when(mockOreMap.getContactTerm()).thenReturn(contactTerm);
+        when(mockOreMap.getContactNameTerm()).thenReturn(contactNameTerm);
+        when(mockOreMap.getContactEmailTerm()).thenReturn(null);
+        when(mockOreMap.getDescriptionTerm()).thenReturn(descriptionTerm);
+        when(mockOreMap.getDescriptionTextTerm()).thenReturn(descriptionTextTerm);
+
+        JsonObjectBuilder contactBuilder = Json.createObjectBuilder();
+        contactBuilder.add(contactNameTerm.getLabel(), "Test Contact");
+        testAggregationBuilder.add(contactTerm.getLabel(), contactBuilder);
+
+        JsonObjectBuilder descriptionBuilder = Json.createObjectBuilder();
+        descriptionBuilder.add(descriptionTextTerm.getLabel(), "Test description");
+        testAggregationBuilder.add(descriptionTerm.getLabel(), descriptionBuilder);
+
+        initializeBagGenerator();
+
+        // Act
+        String infoFile = invokeGenerateInfoFile();
+
+        // Assert
+        assertNotNull(infoFile);
+        assertTrue(infoFile.contains("Contact-Name: Test Contact"));
+        assertTrue(infoFile.contains("External-Description: Test description"));
+        assertTrue(infoFile.contains("Source-Organization:"));
+        assertTrue(infoFile.contains("Organization-Address:"));
+        assertTrue(infoFile.contains("Organization-Email:"));
+        assertTrue(infoFile.contains("Bagging-Date:"));
+        assertTrue(infoFile.contains("External-Identifier: doi:10.5072/FK2/TEST123"));
+        assertTrue(infoFile.contains("Bag-Size:"));
+        assertTrue(infoFile.contains("Payload-Oxum: 1024000.10"));
+        assertTrue(infoFile.contains("Internal-Sender-Identifier: Test Catalog:Test Dataset"));
+    }
+
+    @Test
+    public void testGenerateInfoFileWithDifferentBagSizes() throws Exception {
+        // Arrange
+        JsonLDTerm contactTerm = JsonLDTerm.schemaOrg("creator");
+        when(mockOreMap.getContactTerm()).thenReturn(contactTerm);
+        when(mockOreMap.getContactNameTerm()).thenReturn(null);
+        when(mockOreMap.getContactEmailTerm()).thenReturn(null);
+        when(mockOreMap.getDescriptionTerm()).thenReturn(null);
+
+        initializeBagGenerator();
+
+        // Test with bytes
+        setPrivateField(bagGenerator, "totalDataSize", 512L);
+        setPrivateField(bagGenerator, "dataCount", 5L);
+        String infoFile1 = invokeGenerateInfoFile();
+        assertTrue(infoFile1.contains("Bag-Size: 512 bytes"));
+        assertTrue(infoFile1.contains("Payload-Oxum: 512.5"));
+
+        // Test with KB
+        setPrivateField(bagGenerator, "totalDataSize", 2048L);
+        setPrivateField(bagGenerator, "dataCount", 3L);
+        String infoFile2 = invokeGenerateInfoFile();
+        assertTrue(infoFile2.contains("Bag-Size: 2.05 KB"));
+        assertTrue(infoFile2.contains("Payload-Oxum: 2048.3"));
+
+        // Test with MB
+        setPrivateField(bagGenerator, "totalDataSize", 5242880L);
+        setPrivateField(bagGenerator, "dataCount", 100L);
+        String infoFile3 = invokeGenerateInfoFile();
+        assertTrue(infoFile3.contains("Bag-Size: 5.24 MB"));
+        assertTrue(infoFile3.contains("Payload-Oxum: 5242880.100"));
+
+        // Test with GB
+        setPrivateField(bagGenerator, "totalDataSize", 2147483648L);
+        setPrivateField(bagGenerator, "dataCount", 1000L);
+        
+        String infoFile4 = invokeGenerateInfoFile();
+        assertTrue(infoFile4.contains("Bag-Size: 2.15 GB"));
+        assertTrue(infoFile4.contains("Payload-Oxum: 2147483648.1000"));
+    }
+
+    // Helper methods
+
+    /**
+     * Invokes the private generateInfoFile method using reflection
+     */
+    private String invokeGenerateInfoFile() throws Exception {
+        Method method = BagGenerator.class.getDeclaredMethod("generateInfoFile");
+        method.setAccessible(true);
+        return (String) method.invoke(bagGenerator);
+    }
+
+    /**
+     * Sets a private field value using reflection
+     */
+    private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field field = BagGenerator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagGeneratorMultilineWrapTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/bagit/BagGeneratorMultilineWrapTest.java
@@ -1,0 +1,160 @@
+
+package edu.harvard.iq.dataverse.util.bagit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests adapted for DD-2093: verify the behavior of BagGenerator.multilineWrap.
+ */
+public class BagGeneratorMultilineWrapTest {
+
+    private static Method multilineWrap;
+
+    @BeforeAll
+    static void setUp() throws NoSuchMethodException {
+        // Access the private static method via reflection
+        multilineWrap = BagGenerator.class.getDeclaredMethod("multilineWrap", String.class);
+        multilineWrap.setAccessible(true);
+    }
+
+    private String callMultilineWrap(String input) {
+        try {
+            return (String) multilineWrap.invoke(null, input);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void shortLine_noWrap() {
+        String input = "Hello world";
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo("Hello world");
+    }
+
+    @Test
+    void exactBoundary_78chars_noWrap() {
+        String input = "a".repeat(78);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(input);
+    }
+
+    @Test
+    void longSingleWord_wrapsAt78WithIndent() {
+        String input = "a".repeat(100);
+        String expected = "a".repeat(79) + "\r\n " + "a".repeat(21);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void multiline_input_indentsSecondAndSubsequentOriginalLines() {
+        String input = "Line1\nLine2\nLine3";
+        String expected = "Line1\r\n Line2\r\n Line3";
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void multiline_withLF_normalizedAndIndented() {
+        String input = "a".repeat(200);
+        String expected = "a".repeat(79) + "\r\n " + "a".repeat(78) + "\r\n " + "a".repeat(43);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void emptyLines_trimmedAndSkipped() {
+        String input = "Line1\n\nLine3";
+        String expected = "Line1\r\n Line3";
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void whitespaceOnlyLines_ignored() {
+        String input = "Line1\n   \n\t\t\nLine3";
+        String expected = "Line1\r\n Line3";
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void longSecondLine_preservesIndentOnWraps() {
+        String line1 = "Header";
+        String line2 = "b".repeat(90);
+        String input = line1 + "\n" + line2;
+        String expected = "Header\r\n " + "b".repeat(79) + "\r\n " + "b".repeat(11);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void labelLength_reducesFirstLineMaxLength() {
+        // With a label of length 20, first line should wrap at 78-20=58 chars
+        String label = "l".repeat(20);
+        String input = label + "a".repeat(150);
+        // First line: 58 chars, subsequent lines: 78
+        String expected = label + "a".repeat(59) + "\r\n " + "a".repeat(78) + "\r\n " + "a".repeat(13);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void labelLength_zero_behavesAsDefault() {
+        String input = "a".repeat(100);
+        String expected = "a".repeat(79) + "\r\n " + "a".repeat(21);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void labelLength_withMultipleLines_onlyAffectsFirstLine() {
+        String label = "l".repeat(15);
+        String input = label + "a".repeat(100) + "\nSecond line content";
+        // First line wraps at 79-15=64, then continues at 78 per line
+        // Second line starts fresh and wraps normally
+        String expected = label + "a".repeat(64) + "\r\n " + "a".repeat(36) + "\r\n Second line content";
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void wrapsAtWordBoundary_notMidWord() {
+        // Create a string with a word boundary at position 75
+        // "a" repeated 75 times, then a space, then more characters
+        String input = "a".repeat(75) + " " + "b".repeat(20);
+        // Should wrap at the space (position 75), not at position 79
+        String expected = "a".repeat(75) + "\r\n " + "b".repeat(20);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void wrapsAtWordBoundary_multipleSpaces() {
+        // Test with word boundary closer to the limit
+        String input = "a".repeat(70) + " word " + "b".repeat(20);
+        // Should wrap after "word" (at position 76)
+        String expected = "a".repeat(70) + " word\r\n " + "b".repeat(20);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+
+    @Test
+    void wrapsAtWordBoundary_withLabelLength() {
+        String label = "l".repeat(20);
+        // With label length=20, first line wraps at 78-20=58
+        // Create string with word boundary at position 55
+        String input = label + "a".repeat(55) + " " + "b".repeat(30);
+        // Should wrap at the space (position 55)
+        String expected = label + "a".repeat(55) + "\r\n " + "b".repeat(30);
+        String out = callMultilineWrap(input);
+        assertThat(out).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Fixes DD-2093, DD-2112, DD-1608, DD-2082, DD-2109, DD-2098.

# Description of changes
Merged changes by @qqmyers in the DANS 6.7.1 maintenance/preview branch.

Changes to the exported archival copy BagPack:

* DD-2093: multi-line `bag-info.txt` values are now correctly indented.
* DD-2112: datasets without files get an empty payload manifest of the same algorithm as configured in Dataverse instead of always defaulting to md5.
* DD-1608: the `metadata/oai-ore.jsonld` now contains a URI for the checksum types instead of a literal, as required by JSON-LD.
* DD-2082: No title-based folder in the root of the payload-directory; the datafile path relative to the payload directory is now equal to the path in Dataverse.
* DD-2109: Export of multiple Points of Contact to `bag-info.txt` now works correctly.

Changes to the `archivalStatus` endpoint:

* `curl -H 'X-Dataverse-key: *****' http://localhost:8080/api/datasets/:persistentId/<major>.<minor>/archivalStatus?persistentId=<doi>` now gives the correct status even if version `<major>.<minor>` of `<doi>` is deaccessioned. 

# Related PRs 
* https://github.com/IQSS/dataverse/pull/12063
* https://github.com/IQSS/dataverse/pull/12065

# Notify
@DANS-KNAW/core-systems
