### PR TITLE
DD-2271 separate clients for upload and download

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -347,8 +347,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 // result
                 setInputStream(responseInputStream);
             }
-            catch (InterruptedException | ExecutionException e) {
-                logger.warning("Caught an exception in S3AccessIO.getInputStream(): " + e.getMessage());
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while getting InputStream for S3 Object " + key, e);
+            }
+            catch (ExecutionException e) {
+                throw new IOException("Failed to get InputStream for S3 Object " + key, e);
             }
         }
         if (super.getInputStream() == null) {

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -1,5 +1,21 @@
 package edu.harvard.iq.dataverse.dataaccess;
 
+import edu.harvard.iq.dataverse.DataFile;
+import edu.harvard.iq.dataverse.Dataset;
+import edu.harvard.iq.dataverse.Dataverse;
+import edu.harvard.iq.dataverse.DvObject;
+import edu.harvard.iq.dataverse.datavariable.DataVariable;
+import edu.harvard.iq.dataverse.settings.JvmSettings;
+import edu.harvard.iq.dataverse.util.FileUtil;
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.validation.constraints.NotNull;
+import opennlp.tools.util.StringUtil;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
@@ -16,7 +32,28 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
-import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectTaggingRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -27,15 +64,6 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
-
-import edu.harvard.iq.dataverse.DataFile;
-import edu.harvard.iq.dataverse.Dataset;
-import edu.harvard.iq.dataverse.Dataverse;
-import edu.harvard.iq.dataverse.DvObject;
-import edu.harvard.iq.dataverse.datavariable.DataVariable;
-import edu.harvard.iq.dataverse.settings.JvmSettings;
-import edu.harvard.iq.dataverse.util.FileUtil;
-import opennlp.tools.util.StringUtil;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -58,33 +86,23 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import org.apache.commons.io.IOUtils;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-
-import jakarta.annotation.Resource;
-import jakarta.enterprise.concurrent.ManagedExecutorService;
-import jakarta.json.Json;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.validation.constraints.NotNull;
-
 /**
  *
+ * @param <T> what it stores
  * @author Matthew A Dunlap
  * @author Sarah Ferry
  * @author Rohit Bhattacharjee
  * @author Brian Silverstein
- * @param <T> what it stores
  */
 /*
  * Amazon AWS S3 driver
@@ -108,11 +126,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
     private boolean mainDriver = true;
 
-    private static HashMap<String, S3AsyncClient> driverDownloadClientMap = new HashMap<String, S3AsyncClient>();
-    private static HashMap<String, S3AsyncClient> driverUploadClientMap = new HashMap<String, S3AsyncClient>();
-    private static HashMap<String, S3Presigner> driverPresignerMap = new HashMap<String, S3Presigner>();
-    private static HashMap<String, AwsCredentialsProvider> driverCredentialsProviderMap = new HashMap<String, AwsCredentialsProvider>();
-    private static HashMap<String, S3TransferManager> driverTMMap = new HashMap<String, S3TransferManager>();
+    private static final ConcurrentHashMap<String, S3AsyncClient> driverDownloadClientMap = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, S3AsyncClient> driverUploadClientMap = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, S3Presigner> driverPresignerMap = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, AwsCredentialsProvider> driverCredentialsProviderMap = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, S3TransferManager> driverTMMap = new ConcurrentHashMap<>();
 
     public S3AccessIO(T dvObject, DataAccessRequest req, String driverId) {
         super(dvObject, req, driverId);
@@ -132,10 +150,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 logger.severe(driverId + " config error: Must specify a custom-endpoint-url if proxy-url is specified");
             }
 
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
 
             throw S3Exception.builder().message("Cannot instantiate a S3 client; check your AWS credentials and region")
-                    .cause(e).build();
+                .cause(e).build();
         }
     }
 
@@ -179,7 +198,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         if (isWriteAccessRequested(options)) {
             isWriteAccess = true;
             isReadAccess = false;
-        } else {
+        }
+        else {
             isWriteAccess = false;
             isReadAccess = true;
         }
@@ -208,18 +228,21 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     // Driver id but no bucket
                     if (bucketName != null) {
                         newStorageIdentifier = this.driverId + DataAccess.SEPARATOR + bucketName + ":"
-                                + storageIdentifier.substring((this.driverId + DataAccess.SEPARATOR).length());
-                    } else {
+                            + storageIdentifier.substring((this.driverId + DataAccess.SEPARATOR).length());
+                    }
+                    else {
                         throw new IOException("S3AccessIO: DataFile (storage identifier " + storageIdentifier
-                                + ") is not associated with a bucket.");
+                            + ") is not associated with a bucket.");
                     }
                 } // else we're OK (assumes bucket name in storageidentifier matches the driver's
-                  // bucketname)
-            } else {
+                // bucketname)
+            }
+            else {
                 if (!storageIdentifier.contains(":")) {
                     // No driver id or bucket
                     newStorageIdentifier = this.driverId + DataAccess.SEPARATOR + bucketName + ":" + storageIdentifier;
-                } else {
+                }
+                else {
                     // Just the bucketname
                     newStorageIdentifier = this.driverId + DataAccess.SEPARATOR + storageIdentifier;
                 }
@@ -234,17 +257,18 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 this.setSize(retrieveSizeFromMedia());
 
                 if (dataFile.getContentType() != null && dataFile.getContentType().equals("text/tab-separated-values")
-                        && dataFile.isTabularData() && dataFile.getDataTable() != null && (!this.noVarHeader())
-                        && (!dataFile.getDataTable().isStoredWithVariableHeader())) {
+                    && dataFile.isTabularData() && dataFile.getDataTable() != null && (!this.noVarHeader())
+                    && (!dataFile.getDataTable().isStoredWithVariableHeader())) {
 
                     List<DataVariable> datavariables = dataFile.getDataTable().getDataVariables();
                     String varHeaderLine = generateVariableHeader(datavariables);
                     this.setVarHeader(varHeaderLine);
                 }
 
-            } else if (isWriteAccess) {
+            }
+            else if (isWriteAccess) {
                 key = dataFile.getOwner().getAuthorityForFileStorage() + "/"
-                        + this.getDataFile().getOwner().getIdentifierForFileStorage();
+                    + this.getDataFile().getOwner().getIdentifierForFileStorage();
                 key += "/" + storageIdentifier.substring(storageIdentifier.lastIndexOf(":") + 1);
             }
 
@@ -252,16 +276,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             try {
                 this.setFileName(dataFile.getFileMetadata().getLabel());
-            } catch (Exception ex) {
+            }
+            catch (Exception ex) {
                 this.setFileName("unknown");
             }
-        } else if (dvObject instanceof Dataset) {
+        }
+        else if (dvObject instanceof Dataset) {
             Dataset dataset = this.getDataset();
             key = dataset.getAuthorityForFileStorage() + "/" + dataset.getIdentifierForFileStorage();
             dataset.setStorageIdentifier(this.driverId + DataAccess.SEPARATOR + key);
-        } else if (dvObject instanceof Dataverse) {
+        }
+        else if (dvObject instanceof Dataverse) {
             throw new IOException("Data Access: Storage driver does not support dvObject type Dataverse yet");
-        } else {
+        }
+        else {
             if (isMainDriver()) {
                 // Direct access, e.g. for external upload - no associated DVobject yet, but we
                 // want to be able to get the size
@@ -273,23 +301,26 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     try {
                         // Since s3 is an S3AsyncClient, we need to call .get() to wait for the result.
                         HeadObjectResponse headObjectResponse = s3ReadClient
-                                .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()).get();
+                            .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()).get();
                         contentLength = headObjectResponse.contentLength();
                         if (retries != 20) {
                             logger.warning("Success for key: " + key + " after " + ((20 - retries) * 3) + " seconds");
                         }
                         break;
-                    } catch (Exception e) {
+                    }
+                    catch (Exception e) {
                         if (retries > 1) {
                             retries--;
                             try {
                                 Thread.sleep(3000);
-                            } catch (InterruptedException ie) {
+                            }
+                            catch (InterruptedException ie) {
                                 Thread.currentThread().interrupt();
                                 logger.warning("Thread interrupted while waiting to retry");
                             }
                             logger.warning("Retrying after: " + e.getMessage());
-                        } else {
+                        }
+                        else {
                             throw new IOException("Cannot get S3 object " + key + " (" + e.getMessage() + ")", e);
                         }
                     }
@@ -297,7 +328,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
                 if (contentLength >= 0) {
                     this.setSize(contentLength);
-                } else {
+                }
+                else {
                     throw new IOException("Failed to retrieve content length for S3 object " + key);
                 }
             }
@@ -310,11 +342,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             ResponseInputStream<GetObjectResponse> responseInputStream;
             try {
                 responseInputStream = s3ReadClient.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
-                        AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
-                                                                                 // need to call .get() to wait for the
-                                                                                 // result
+                    AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
+                // need to call .get() to wait for the
+                // result
                 setInputStream(responseInputStream);
-            } catch (InterruptedException | ExecutionException e) {
+            }
+            catch (InterruptedException | ExecutionException e) {
                 logger.warning("Caught an exception in S3AccessIO.getInputStream(): " + e.getMessage());
             }
         }
@@ -356,15 +389,17 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             try {
                 tm.uploadFile(
                         UploadFileRequest.builder().putObjectRequest(req -> req.bucket(bucketName).key(key)).source(fileSystemPath).build())
-                        .completionFuture().join();
+                    .completionFuture().join();
 
                 newFileSize = Files.size(fileSystemPath);
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 logger.warning("Caught an exception in S3AccessIO.savePath(): " + e.getMessage());
                 throw new IOException(
-                        "S3AccessIO: Exception occurred while uploading a local file into S3Object " + key, e);
+                    "S3AccessIO: Exception occurred while uploading a local file into S3Object " + key, e);
             }
-        } else {
+        }
+        else {
             throw new IOException("DvObject type other than datafile is not yet supported");
         }
 
@@ -377,7 +412,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     public void saveInputStream(InputStream inputStream, Long filesize) throws IOException {
         if (filesize == null || filesize < 0) {
             saveInputStream(inputStream);
-        } else {
+        }
+        else {
             saveInputStreamInternal(inputStream, filesize);
         }
     }
@@ -401,7 +437,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (filesize != null) {
                 putObjectRequestBuilder.contentLength(filesize);
                 asyncRequestBody = AsyncRequestBody.fromInputStream(inputStream, filesize, executorService);
-            } else {
+            }
+            else {
                 String directoryString = FileUtil.getFilesTempDirectory();
                 Random rand = new Random();
                 Path tempPath = Paths.get(directoryString, Integer.toString(rand.nextInt(Integer.MAX_VALUE)));
@@ -413,18 +450,21 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             if (filesize == null) {
                 HeadObjectResponse headObjectResponse = s3ReadClient
-                        .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()).get();
+                    .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()).get();
                 setSize(headObjectResponse.contentLength());
-            } else {
+            }
+            else {
                 setSize(filesize);
             }
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             String failureMsg = e.getMessage();
             if (failureMsg == null) {
                 failureMsg = "S3AccessIO: Unknown exception occurred while uploading a file into S3 Storage.";
             }
             throw new IOException(failureMsg, e);
-        } finally {
+        }
+        finally {
             if (tempFile != null) {
                 tempFile.delete();
             }
@@ -445,8 +485,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             DeleteObjectRequest deleteObjRequest = DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
             s3WriteClient.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                     // the result
-        } catch (InterruptedException | ExecutionException e) {
+            // the result
+        }
+        catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
             throw new IOException("Failed to delete storage location " + getStorageLocation(), e);
         }
@@ -460,7 +501,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         if (isWriteAccessRequested(options)) {
             // Need size to write to S3
             throw new UnsupportedDataAccessOperationException(
-                    "S3AccessIO: write mode openAuxChannel() not yet implemented in this storage driver.");
+                "S3AccessIO: write mode openAuxChannel() not yet implemented in this storage driver.");
         }
 
         InputStream fin = getAuxFileAsInputStream(auxItemTag);
@@ -479,12 +520,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucketName).key(destinationKey)
-                    .build();
+                .build();
 
             s3ReadClient.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
             return true;
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 // Object doesn't exist
                 return false;
@@ -500,23 +542,24 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             HeadObjectResponse headObjectResponse = s3ReadClient
-                    .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
-                                                                                                                   // s3
-                                                                                                                   // is
-                                                                                                                   // an
-                                                                                                                   // S3AsyncClient,
-                                                                                                                   // we
-                                                                                                                   // need
-                                                                                                                   // to
-                                                                                                                   // call
-                                                                                                                   // .get()
-                                                                                                                   // to
-                                                                                                                   // wait
-                                                                                                                   // for
-                                                                                                                   // the
-                                                                                                                   // result
+                .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
+            // s3
+            // is
+            // an
+            // S3AsyncClient,
+            // we
+            // need
+            // to
+            // call
+            // .get()
+            // to
+            // wait
+            // for
+            // the
+            // result
             return headObjectResponse.contentLength();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 // Object doesn't exist
                 logger.warning("Auxiliary object not found: " + destinationKey);
@@ -530,7 +573,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     @Override
     public Path getAuxObjectAsPath(String auxItemTag) throws UnsupportedDataAccessOperationException {
         throw new UnsupportedDataAccessOperationException(
-                "S3AccessIO: this is a remote DataAccess IO object, its Aux objects have no local filesystem Paths associated with it.");
+            "S3AccessIO: this is a remote DataAccess IO object, its Aux objects have no local filesystem Paths associated with it.");
     }
 
     @Override
@@ -538,11 +581,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder().sourceBucket(bucketName).sourceKey(key)
-                    .destinationBucket(bucketName).destinationKey(destinationKey).build();
+                .destinationBucket(bucketName).destinationKey(destinationKey).build();
 
             s3WriteClient.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
-        } catch (InterruptedException | ExecutionException e) {
+            // the result
+        }
+        catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
         }
@@ -553,12 +597,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder().sourceBucket(bucketName)
-                    .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
+                .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
 
             s3WriteClient.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
-                                                    // the result
+            // the result
             deleteAuxObject(auxItemTag);
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to revert backup auxiliary object", e);
         }
@@ -572,11 +617,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucketName).key(destinationKey)
-                    .build();
+                .build();
             AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromFile(fileSystemPath);
             s3WriteClient.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                                                                    // .get() to wait for the result
-        } catch (InterruptedException | ExecutionException e) {
+            // .get() to wait for the result
+        }
+        catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
             throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
         }
@@ -586,21 +632,23 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     public void saveInputStreamAsAux(InputStream inputStream, String auxItemTag, Long filesize) throws IOException {
         if (filesize == null || filesize < 0) {
             saveInputStreamAsAux(inputStream, auxItemTag);
-        } else {
+        }
+        else {
             if (!this.canWrite()) {
                 open(DataAccessOption.WRITE_ACCESS);
             }
             String destinationKey = getDestinationKey(auxItemTag);
             try {
                 PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucketName).key(destinationKey)
-                        .contentLength(filesize).build();
+                    .contentLength(filesize).build();
 
                 AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromInputStream(inputStream, filesize,
-                        executorService);
+                    executorService);
 
                 s3WriteClient.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
-                                                                        // .get() to wait for the result
-            } catch (InterruptedException | ExecutionException e) {
+                // .get() to wait for the result
+            }
+            catch (InterruptedException | ExecutionException e) {
                 String failureMsg = e.getMessage();
 
                 if (failureMsg == null) {
@@ -612,19 +660,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * Implements the StorageIO saveInputStreamAsAux() method. This implementation
-     * is problematic, because S3 cannot save an object of an unknown length. This
-     * effectively nullifies any benefits of streaming; as we cannot start saving
-     * until we have read the entire stream. One way of solving this would be to
-     * buffer the entire stream as byte[], in memory, then save it... Which of
-     * course would be limited by the amount of memory available, and thus would not
-     * work for streams larger than that. So we have eventually decided to save save
-     * the stream to a temp file, then save to S3. This is slower, but guaranteed to
-     * work on any size stream. An alternative we may want to consider is to not
-     * implement this method in the S3 driver, and make it throw the
-     * UnsupportedDataAccessOperationException, similarly to how we handle attempts
-     * to open OutputStreams, in this and the Swift driver.
-     * 
+     * Implements the StorageIO saveInputStreamAsAux() method. This implementation is problematic, because S3 cannot save an object of an unknown length. This effectively nullifies any benefits of
+     * streaming; as we cannot start saving until we have read the entire stream. One way of solving this would be to buffer the entire stream as byte[], in memory, then save it... Which of course
+     * would be limited by the amount of memory available, and thus would not work for streams larger than that. So we have eventually decided to save save the stream to a temp file, then save to S3.
+     * This is slower, but guaranteed to work on any size stream. An alternative we may want to consider is to not implement this method in the S3 driver, and make it throw the
+     * UnsupportedDataAccessOperationException, similarly to how we handle attempts to open OutputStreams, in this and the Swift driver.
+     *
      * @param inputStream InputStream we want to save
      * @param auxItemTag  String representing this Auxiliary type ("extension")
      * @throws IOException if anything goes wrong.
@@ -654,19 +695,22 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             // Use the async client to put the object
             s3WriteClient.putObject(putObjectRequest, requestBody).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             String failureMsg = e.getMessage();
 
             if (failureMsg == null) {
                 failureMsg = "S3AccessIO: Exception occurred while saving a local InputStream as S3Object";
             }
             throw new IOException(failureMsg, e);
-        } finally {
+        }
+        finally {
             // Close the input stream
             if (inputStream != null) {
                 try {
                     inputStream.close();
-                } catch (IOException e) {
+                }
+                catch (IOException e) {
                     logger.warning("Failed to close input stream: " + e.getMessage());
                 }
             }
@@ -692,7 +736,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 outStream.write(buffer, 0, bytesRead);
             }
 
-        } finally {
+        }
+        finally {
             IOUtils.closeQuietly(inputStream);
         }
         return targetFile;
@@ -707,12 +752,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
         List<String> ret = new ArrayList<>();
         ListObjectsV2Request listObjectsReqManual = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
-                .build();
+            .build();
 
         ListObjectsV2Response listObjectsResponse = null;
         try {
             listObjectsResponse = s3ReadClient.listObjectsV2(listObjectsReqManual).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3 listAuxObjects: failed to get a listing for " + prefix, e);
         }
 
@@ -727,17 +773,19 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             while (nextContinuationToken != null) {
                 logger.fine("S3 listAuxObjects: going to next page of list");
                 ListObjectsV2Request nextReq = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
-                        .continuationToken(nextContinuationToken).build();
+                    .continuationToken(nextContinuationToken).build();
 
                 ListObjectsV2Response nextResponse = s3ReadClient.listObjectsV2(nextReq).get();
                 if (nextResponse != null) {
                     storedAuxFilesSummary.addAll(nextResponse.contents());
                     nextContinuationToken = nextResponse.nextContinuationToken();
-                } else {
+                }
+                else {
                     nextContinuationToken = null;
                 }
             }
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to get aux objects for listing.", e);
         }
 
@@ -758,11 +806,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder().bucket(bucketName)
-                    .key(destinationKey).build();
+                .key(destinationKey).build();
 
             s3WriteClient.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
-                                                        // for the result
-        } catch (InterruptedException | ExecutionException e) {
+            // for the result
+        }
+        catch (InterruptedException | ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
             throw new IOException("Failed to delete auxiliary object", e);
         }
@@ -786,9 +835,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 storedAuxFilesSummary.addAll(listResponse.contents());
 
                 listRequest = listRequest.toBuilder().continuationToken(listResponse.nextContinuationToken()).build();
-            } while (listResponse.isTruncated());
+            }
+            while (listResponse.isTruncated());
 
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to get aux objects for listing to delete.", e);
         }
 
@@ -798,7 +849,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         }
 
         List<ObjectIdentifier> objectsToDelete = storedAuxFilesSummary.stream()
-                .map(s3Object -> ObjectIdentifier.builder().key(s3Object.key()).build()).collect(Collectors.toList());
+            .map(s3Object -> ObjectIdentifier.builder().key(s3Object.key()).build()).collect(Collectors.toList());
 
         Delete delete = Delete.builder().objects(objectsToDelete).quiet(true).build();
 
@@ -807,7 +858,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         logger.fine("Trying to delete auxiliary files...");
         try {
             s3WriteClient.deleteObjects(deleteRequest).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to delete one or more auxiliary objects.", e);
         }
     }
@@ -826,33 +878,37 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     @Override
     public Path getFileSystemPath() throws UnsupportedDataAccessOperationException {
         throw new UnsupportedDataAccessOperationException(
-                "S3AccessIO: this is a remote DataAccess IO object, it has no local filesystem path associated with it.");
+            "S3AccessIO: this is a remote DataAccess IO object, it has no local filesystem path associated with it.");
     }
 
     @Override
     public boolean exists() {
         try {
             key = getMainFileKey();
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             logger.warning("Caught an IOException in S3AccessIO.exists(): " + e.getMessage());
             return false;
         }
         String destinationKey = null;
         if (dvObject instanceof DataFile) {
             destinationKey = key;
-        } else if ((dvObject == null) && (key != null)) {
+        }
+        else if ((dvObject == null) && (key != null)) {
             // direct access
             destinationKey = key;
-        } else {
+        }
+        else {
             logger.warning("Trying to check if a path exists is only supported for a data file.");
         }
         try {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucketName).key(destinationKey)
-                    .build();
+                .build();
 
             s3ReadClient.headObject(headObjectRequest).get();
             return true;
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 // Object does not exist
                 return false;
@@ -865,13 +921,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     @Override
     public WritableByteChannel getWriteChannel() throws UnsupportedDataAccessOperationException {
         throw new UnsupportedDataAccessOperationException(
-                "S3AccessIO: there are no write Channels associated with S3 objects.");
+            "S3AccessIO: there are no write Channels associated with S3 objects.");
     }
 
     @Override
     public OutputStream getOutputStream() throws UnsupportedDataAccessOperationException {
         throw new UnsupportedDataAccessOperationException(
-                "S3AccessIO: there are no output Streams associated with S3 objects.");
+            "S3AccessIO: there are no output Streams associated with S3 objects.");
     }
 
     @Override
@@ -879,15 +935,16 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String destinationKey = getDestinationKey(auxItemTag);
         try {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(destinationKey)
-                    .build();
+                .build();
 
             ResponseInputStream<GetObjectResponse> s3ObjectContent = s3ReadClient
-                    .getObject(getObjectRequest, AsyncResponseTransformer.toBlockingInputStream()).get();
+                .getObject(getObjectRequest, AsyncResponseTransformer.toBlockingInputStream()).get();
             if (s3ObjectContent != null) {
                 return s3ObjectContent;
             }
             return null;
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 logger.fine("S3AccessIO.getAuxFileAsInputStream(): Object not found (not cached?): " + e.getMessage());
                 return null;
@@ -901,12 +958,14 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     String getDestinationKey(String auxItemTag) throws IOException {
         if (isDirectAccess() || dvObject instanceof DataFile) {
             return getMainFileKey() + "." + auxItemTag;
-        } else if (dvObject instanceof Dataset) {
+        }
+        else if (dvObject instanceof Dataset) {
             if (key == null) {
                 open();
             }
             return key + "/" + auxItemTag;
-        } else {
+        }
+        else {
             throw new IOException("S3AccessIO: This operation is only supported for Datasets and DataFiles.");
         }
     }
@@ -918,7 +977,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
      * Extract the file key from a file stored on S3. Follows template: "owner
      * authority name"/"owner identifier"/"storage identifier without bucketname and
      * protocol"
-     * 
+     *
      * @return Main File Key
      * @throws IOException
      */
@@ -958,9 +1017,10 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // String bucketName = storageIdentifier.substring(driverId.length() + 3,
             // storageIdentifier.lastIndexOf(":"));
             key = baseKey + "/" + storageIdentifier.substring(storageIdentifier.lastIndexOf(":") + 1);
-        } else {
+        }
+        else {
             throw new IOException("S3AccessIO: DataFile (storage identifier " + storageIdentifier
-                    + ") does not appear to be an S3 object associated with driver: " + driverId);
+                + ") does not appear to be an S3 object associated with driver: " + driverId);
         }
         return key;
     }
@@ -979,19 +1039,16 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     /**
-     * Generates a temporary URL for a direct S3 download; either for the main
-     * physical file, or (optionally) for an auxiliary.
-     * 
+     * Generates a temporary URL for a direct S3 download; either for the main physical file, or (optionally) for an auxiliary.
+     *
      * @param auxiliaryTag      (optional)
-     * @param auxiliaryType     (optional) - aux. mime type, if different from the
-     *                          main type
-     * @param auxiliaryFileName (optional) - file name, if different from the main
-     *                          file label.
+     * @param auxiliaryType     (optional) - aux. mime type, if different from the main type
+     * @param auxiliaryFileName (optional) - file name, if different from the main file label.
      * @return redirect url
      * @throws IOException
      */
     public String generateTemporaryDownloadUrl(String auxiliaryTag, String auxiliaryType, String auxiliaryFileName)
-            throws IOException {
+        throws IOException {
         if (s3ReadClient == null || s3WriteClient == null) {
             throw new IOException("ERROR: s3 not initialised. ");
         }
@@ -1003,21 +1060,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             String contentType = auxiliaryType == null ? this.getDataFile().getContentType() : auxiliaryType;
 
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                    .signatureDuration(expirationDuration)
-                    .getObjectRequest(req -> req.bucket(bucketName).key(key)
-                            .responseContentDisposition("attachment; filename*=UTF-8''"
-                                    + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
-                            .responseContentType(contentType))
-                    .build();
+                .signatureDuration(expirationDuration)
+                .getObjectRequest(req -> req.bucket(bucketName).key(key)
+                    .responseContentDisposition("attachment; filename*=UTF-8''"
+                        + URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20"))
+                    .responseContentType(contentType))
+                .build();
 
             PresignedGetObjectRequest presignedRequest;
             try {
                 presignedRequest = s3Presigner.presignGetObject(presignRequest);
-            } catch (S3Exception e) {
+            }
+            catch (S3Exception e) {
                 logger.warning("Exception generating temporary S3 url for " + key + " (" + e.getMessage() + ")");
                 return null;
-            } finally {
-                s3Presigner.close();
             }
 
             if (presignedRequest != null) {
@@ -1033,17 +1089,21 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     String finalUrl = urlString.replaceFirst("http[s]*:\\/\\/([^\\/]+\\.)" + endpointServer, proxy);
                     logger.fine("ProxiedURL: " + finalUrl);
                     return finalUrl;
-                } else {
+                }
+                else {
                     return urlString;
                 }
             }
 
             return null;
-        } else if (dvObject instanceof Dataset) {
+        }
+        else if (dvObject instanceof Dataset) {
             throw new IOException("Data Access: GenerateTemporaryS3Url: Invalid DvObject type : Dataset");
-        } else if (dvObject instanceof Dataverse) {
+        }
+        else if (dvObject instanceof Dataverse) {
             throw new IOException("Data Access: GenerateTemporaryS3Url: Invalid DvObject type : Dataverse");
-        } else {
+        }
+        else {
             throw new IOException("Data Access: GenerateTemporaryS3Url: Unknown DvObject type");
         }
     }
@@ -1056,14 +1116,15 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         Duration expirationDuration = Duration.between(Instant.now(), expiration.toInstant());
 
         PutObjectPresignRequest.Builder presignRequestBuilder = PutObjectPresignRequest.builder()
-                .signatureDuration(expirationDuration);
+            .signatureDuration(expirationDuration);
 
         // Add tagging if not disabled
         final boolean taggingDisabled = JvmSettings.DISABLE_S3_TAGGING.lookupOptional(Boolean.class, this.driverId)
-                .orElse(false);
+            .orElse(false);
         if (!taggingDisabled) {
             presignRequestBuilder.putObjectRequest(req -> req.tagging("dv-state=temp").bucket(bucketName).key(key));
-        } else {
+        }
+        else {
             presignRequestBuilder.putObjectRequest(req -> req.bucket(bucketName).key(key));
         }
         PutObjectPresignRequest presignRequest = presignRequestBuilder.build();
@@ -1071,11 +1132,10 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         PresignedPutObjectRequest presignedRequest;
         try {
             presignedRequest = s3Presigner.presignPutObject(presignRequest);
-        } catch (S3Exception e) {
+        }
+        catch (S3Exception e) {
             logger.warning("Exception generating temporary S3 upload url for " + key + " (" + e.getMessage() + ")");
             return null;
-        } finally {
-            s3Presigner.close();
         }
 
         String urlString = presignedRequest.url().toString();
@@ -1099,18 +1159,19 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     public JsonObjectBuilder generateTemporaryS3UploadUrls(String globalId, String storageIdentifier, long fileSize)
-            throws IOException {
+        throws IOException {
         JsonObjectBuilder response = Json.createObjectBuilder();
         key = getMainFileKey();
         Instant expiration = Instant.now().plus(Duration.ofMinutes(getUrlExpirationMinutes()));
 
         if (fileSize <= minPartSize) {
             response.add("url", generateTemporaryS3UploadUrl(key, Date.from(expiration)));
-        } else {
+        }
+        else {
             JsonObjectBuilder urls = Json.createObjectBuilder();
 
             CreateMultipartUploadRequest.Builder createMultipartUploadRequestBuilder = CreateMultipartUploadRequest
-                    .builder().bucket(bucketName).key(key);
+                .builder().bucket(bucketName).key(key);
 
             // Use the existing s3 async client for the createMultipartUpload operation
             CompletableFuture<CreateMultipartUploadResponse> createMultipartUploadFuture = s3WriteClient.createMultipartUpload(createMultipartUploadRequestBuilder.build());
@@ -1120,9 +1181,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             for (int i = 1; i <= (fileSize / minPartSize) + (fileSize % minPartSize > 0 ? 1 : 0); i++) {
                 final int partNum = i;
                 PresignedUploadPartRequest presignedRequest = s3Presigner.presignUploadPart(UploadPartPresignRequest
-                        .builder().signatureDuration(Duration.between(Instant.now(), expiration))
-                        .uploadPartRequest(b -> b.bucket(bucketName).key(key).uploadId(uploadId).partNumber(partNum))
-                        .build());
+                    .builder().signatureDuration(Duration.between(Instant.now(), expiration))
+                    .uploadPartRequest(b -> b.bucket(bucketName).key(key).uploadId(uploadId).partNumber(partNum))
+                    .build());
 
                 String urlString = presignedRequest.url().toString();
                 if (!StringUtil.isEmpty(proxy)) {
@@ -1133,11 +1194,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             response.add("urls", urls);
             response.add("abort", "/api/datasets/mpupload?globalid=" + globalId + "&uploadid=" + uploadId
-                    + "&storageidentifier=" + storageIdentifier);
+                + "&storageidentifier=" + storageIdentifier);
             response.add("complete", "/api/datasets/mpupload?globalid=" + globalId + "&uploadid=" + uploadId
-                    + "&storageidentifier=" + storageIdentifier);
-
-            s3Presigner.close();
+                + "&storageidentifier=" + storageIdentifier);
         }
 
         response.add("partSize", minPartSize);
@@ -1151,7 +1210,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             Integer num;
             try {
                 num = Integer.parseInt(optionValue);
-            } catch (NumberFormatException ex) {
+            }
+            catch (NumberFormatException ex) {
                 num = null;
             }
             if (num != null) {
@@ -1177,29 +1237,28 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 long val = Long.parseLong(partLength);
                 if (val >= min) {
                     min = val;
-                } else {
-                    logger.warning(min + " is the minimum part size allowed for jvm option dataverse.files." + driverId
-                            + ".min-part-size");
                 }
-            } else {
+                else {
+                    logger.warning(min + " is the minimum part size allowed for jvm option dataverse.files." + driverId
+                        + ".min-part-size");
+                }
+            }
+            else {
                 min = 1024 * 1024 * 1024l;
             }
-        } catch (NumberFormatException nfe) {
+        }
+        catch (NumberFormatException nfe) {
             logger.warning("Unable to parse dataverse.files." + driverId + ".min-part-size as long: " + partLength);
         }
         return min;
     }
 
     private static S3TransferManager getTransferManager(String driverId) {
-        if (driverTMMap.containsKey(driverId)) {
-            return driverTMMap.get(driverId);
-        } else {
+        return driverTMMap.computeIfAbsent(driverId, id -> {
             // building a TransferManager instance to support multipart uploading for files
             // over 4gb.
-            S3TransferManager manager = S3TransferManager.builder().s3Client(getWriteClient(driverId)).build();
-            driverTMMap.put(driverId, manager);
-            return manager;
-        }
+            return S3TransferManager.builder().s3Client(getWriteClient(id)).build();
+        });
     }
 
     private static S3AsyncClient getReadClient(String driverId) {
@@ -1211,15 +1270,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     private static S3AsyncClient getClient(String driverId, boolean upload) {
-        HashMap<String, S3AsyncClient> clientMap = upload ? driverUploadClientMap : driverDownloadClientMap;
-        if (clientMap.containsKey(driverId)) {
-            return clientMap.get(driverId);
-        } else {
+        ConcurrentHashMap<String, S3AsyncClient> clientMap = upload ? driverUploadClientMap : driverDownloadClientMap;
+        return clientMap.computeIfAbsent(driverId, id -> {
             // Create a builder for the S3AsyncClient
             S3AsyncClientBuilder s3CB = S3AsyncClient.builder().requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
 
             // Create a custom HTTP client with the desired pool size
-            Integer poolSize = Integer.getInteger("dataverse.files." + driverId + ".connection-pool-size", 256);
+            Integer poolSize = Integer.getInteger("dataverse.files." + id + ".connection-pool-size", 256);
             Builder httpClientBuilder = NettyNioAsyncHttpClient.builder().maxConcurrency(poolSize);
 
             // Apply the custom HTTP client to the S3AsyncClientBuilder
@@ -1228,17 +1285,18 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             if (upload) {
                 // Enable multipart and configure it to be used if the file is larger than minPartSize.
                 s3CB.multipartEnabled(true);
-                long minPartSize = getMinPartSize(driverId);
+                long minPartSize = getMinPartSize(id);
                 s3CB.multipartConfiguration(MultipartConfiguration.builder()
                     .thresholdInBytes(minPartSize)
                     .minimumPartSizeInBytes(minPartSize).build());
-            } else {
+            }
+            else {
                 s3CB.multipartEnabled(false);
             }
 
             // Configure endpoint and region
-            String s3CEUrl = getConfigParamForDriver(driverId, CUSTOM_ENDPOINT_URL, "");
-            String s3CERegion = getConfigParamForDriver(driverId, CUSTOM_ENDPOINT_REGION, "dataverse");
+            String s3CEUrl = getConfigParamForDriver(id, CUSTOM_ENDPOINT_URL, "");
+            String s3CERegion = getConfigParamForDriver(id, CUSTOM_ENDPOINT_REGION, "dataverse");
 
             if (!s3CEUrl.isEmpty()) {
                 s3CB.endpointOverride(URI.create(s3CEUrl));
@@ -1247,22 +1305,20 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             // Configure path style access
             boolean s3pathStyleAccess = Boolean
-                    .parseBoolean(getConfigParamForDriver(driverId, PATH_STYLE_ACCESS, "false"));
+                .parseBoolean(getConfigParamForDriver(id, PATH_STYLE_ACCESS, "false"));
             s3CB.forcePathStyle(s3pathStyleAccess);
             // Configure chunked encoding
 
             Boolean s3chunkedEncoding = Boolean
-                    .parseBoolean(getConfigParamForDriver(driverId, CHUNKED_ENCODING, "true"));
+                .parseBoolean(getConfigParamForDriver(id, CHUNKED_ENCODING, "true"));
             s3CB.serviceConfiguration(S3Configuration.builder().chunkedEncodingEnabled(s3chunkedEncoding).build());
 
             // Configure credentials
-            s3CB.credentialsProvider(getCredentialsProvider(driverId));
+            s3CB.credentialsProvider(getCredentialsProvider(id));
 
             // Build the client
-            S3AsyncClient client = s3CB.build();
-            clientMap.put(driverId, client);
-            return client;
-        }
+            return s3CB.build();
+        });
     }
 
     private static S3AsyncClient getClient(String driverId) {
@@ -1270,52 +1326,46 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     private static S3Presigner getPresigner(String driverId) {
-        if (driverPresignerMap.containsKey(driverId)) {
-            return driverPresignerMap.get(driverId);
-        } else {
-            S3AsyncClient s3 = getClient(driverId);
+        return driverPresignerMap.computeIfAbsent(driverId, id -> {
+            S3AsyncClient s3 = getClient(id);
             S3Presigner.Builder s3PresignerBuilder = S3Presigner.builder()
-                    .region(Region.of(s3.serviceClientConfiguration().region().toString()))
-                    .credentialsProvider(getCredentialsProvider(driverId));
+                .region(Region.of(s3.serviceClientConfiguration().region().toString()))
+                .credentialsProvider(getCredentialsProvider(id));
 
             s3.serviceClientConfiguration().endpointOverride()
-                    .ifPresent(uri -> s3PresignerBuilder.endpointOverride(uri));
+                .ifPresent(uri -> s3PresignerBuilder.endpointOverride(uri));
 
             // Add path style access configuration
             Boolean s3pathStyleAccess = Boolean
-                    .parseBoolean(getConfigParamForDriver(driverId, PATH_STYLE_ACCESS, "false"));
+                .parseBoolean(getConfigParamForDriver(id, PATH_STYLE_ACCESS, "false"));
             s3PresignerBuilder
-                    .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(s3pathStyleAccess).build());
-            S3Presigner s3Presigner = s3PresignerBuilder.build();
-            driverPresignerMap.put(driverId, s3Presigner);
-            return s3Presigner;
-        }
-
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(s3pathStyleAccess).build());
+            return s3PresignerBuilder.build();
+        });
     }
-    
+
     private static AwsCredentialsProvider getCredentialsProvider(String driverId) {
-        if (driverCredentialsProviderMap.containsKey(driverId)) {
-            return driverCredentialsProviderMap.get(driverId);
-        } else {
+        return driverCredentialsProviderMap.computeIfAbsent(driverId, id -> {
             List<AwsCredentialsProvider> providers = new ArrayList<>();
 
-            String s3profile = getConfigParamForDriver(driverId, PROFILE);
+            String s3profile = getConfigParamForDriver(id, PROFILE);
             boolean allowInstanceCredentials = true;
 
             if (s3profile != null) {
                 allowInstanceCredentials = false;
             }
 
-            Optional<String> accessKey = config.getOptionalValue("dataverse.files." + driverId + ".access-key",
-                    String.class);
-            Optional<String> secretKey = config.getOptionalValue("dataverse.files." + driverId + ".secret-key",
-                    String.class);
+            Optional<String> accessKey = config.getOptionalValue("dataverse.files." + id + ".access-key",
+                String.class);
+            Optional<String> secretKey = config.getOptionalValue("dataverse.files." + id + ".secret-key",
+                String.class);
 
             if (accessKey.isPresent() && secretKey.isPresent()) {
                 allowInstanceCredentials = false;
                 providers.add(
-                        StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey.get(), secretKey.get())));
-            } else if (s3profile == null) {
+                    StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey.get(), secretKey.get())));
+            }
+            else if (s3profile == null) {
                 s3profile = "default";
             }
 
@@ -1328,11 +1378,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             }
 
             Collections.reverse(providers);
-            AwsCredentialsProvider provider = AwsCredentialsProviderChain.builder().credentialsProviders(providers)
-                    .build();
-            driverCredentialsProviderMap.put(driverId, provider);
-            return provider;
-        }
+            return AwsCredentialsProviderChain.builder().credentialsProviders(providers)
+                .build();
+        });
     }
 
     public void removeTempTag() throws IOException {
@@ -1343,41 +1391,46 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             key = getMainFileKey();
             DeleteObjectTaggingRequest deleteObjectTaggingRequest = DeleteObjectTaggingRequest.builder()
-                    .bucket(bucketName).key(key).build();
+                .bucket(bucketName).key(key).build();
             // Note - currently we only use one tag so delete is the fastest and cheapest
             // way to get rid of that one tag
             // Otherwise you have to get tags, remove the one you don't want and post new
             // tags and get charged for the operations
             s3WriteClient.deleteObjectTagging(deleteObjectTaggingRequest).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
                     // In this case, it's likely that tags are not implemented at all (e.g. by
                     // Minio) so no tag was set either and it's just something to be aware of
                     logger.warning("Temp tag not deleted: Object tags not supported by storage: " + driverId);
-                } else {
+                }
+                else {
                     // In this case, the assumption is that adding tags has worked, so not removing
                     // it is a problem that should be looked into.
                     logger.severe("Unable to remove temp tag from : " + bucketName + " : " + key);
                 }
-            } else {
+            }
+            else {
                 logger.severe("Unexpected error while removing temp tag: " + e.getMessage());
                 throw new IOException("Failed to remove temp tag", e);
             }
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             logger.warning("Could not create key for S3 object.");
             throw e;
         }
     }
 
     public static void abortMultipartUpload(String globalId, String storageIdentifier, String uploadId)
-            throws IOException {
+        throws IOException {
         String baseKey = null;
         int index = globalId.indexOf(":");
         if (index >= 0) {
             baseKey = globalId.substring(index + 1);
-        } else {
+        }
+        else {
             throw new IOException("Invalid Global ID (expected form with '<type>:' prefix)");
         }
         String[] info = DataAccess.getDriverIdAndStorageLocation(storageIdentifier);
@@ -1387,22 +1440,28 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String key = getMainFileKey(baseKey, storageIdentifier, driverId);
 
         AbortMultipartUploadRequest req = AbortMultipartUploadRequest.builder().bucket(bucketName).key(key)
-                .uploadId(uploadId).build();
+            .uploadId(uploadId).build();
 
         try {
             s3Client.abortMultipartUpload(req).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Failed to abort multipart upload", e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("Failed to abort multipart upload", e);
         }
     }
 
     public static void completeMultipartUpload(String globalId, String storageIdentifier, String uploadId,
-            List<CompletedPart> completedParts) throws IOException {
+        List<CompletedPart> completedParts) throws IOException {
         String baseKey = null;
         int index = globalId.indexOf(":");
         if (index >= 0) {
             baseKey = globalId.substring(index + 1);
-        } else {
+        }
+        else {
             throw new IOException("Invalid Global ID (expected form with '<type>:' prefix)");
         }
 
@@ -1413,14 +1472,15 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String key = getMainFileKey(baseKey, storageIdentifier, driverId);
 
         CompletedMultipartUpload completedMultipartUpload = CompletedMultipartUpload.builder().parts(completedParts)
-                .build();
+            .build();
 
         CompleteMultipartUploadRequest completeMultipartUploadRequest = CompleteMultipartUploadRequest.builder()
-                .bucket(bucketName).key(key).uploadId(uploadId).multipartUpload(completedMultipartUpload).build();
+            .bucket(bucketName).key(key).uploadId(uploadId).multipartUpload(completedMultipartUpload).build();
 
         try {
             s3Client.completeMultipartUpload(completeMultipartUploadRequest).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("Failed to complete multipart upload", e);
         }
     }
@@ -1477,12 +1537,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
         List<String> ret = new ArrayList<>();
         ListObjectsV2Request listObjectsReqManual = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
-                .build();
+            .build();
 
         ListObjectsV2Response listObjectsResponse = null;
         try {
             listObjectsResponse = s3ReadClient.listObjectsV2(listObjectsReqManual).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3 listObjects: failed to get a listing for " + prefix, e);
         }
 
@@ -1497,17 +1558,19 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             while (nextContinuationToken != null) {
                 logger.fine("S3 listObjects: going to next page of list");
                 ListObjectsV2Request nextReq = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
-                        .continuationToken(nextContinuationToken).build();
+                    .continuationToken(nextContinuationToken).build();
 
                 ListObjectsV2Response nextResponse = s3ReadClient.listObjectsV2(nextReq).get();
                 if (nextResponse != null) {
                     storedFilesSummary.addAll(nextResponse.contents());
                     nextContinuationToken = nextResponse.nextContinuationToken();
-                } else {
+                }
+                else {
                     nextContinuationToken = null;
                 }
             }
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to get objects for listing.", e);
         }
 
@@ -1529,29 +1592,32 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         String prefix = dataset.getAuthorityForFileStorage() + "/" + dataset.getIdentifierForFileStorage() + "/";
 
         DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder().bucket(bucketName)
-                .key(prefix + fileName).build();
+            .key(prefix + fileName).build();
 
         try {
             s3WriteClient.deleteObject(deleteObjectRequest).get();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 logger.warning("S3AccessIO: Unable to delete object " + s3e.getMessage());
-            } else {
+            }
+            else {
                 logger.warning("S3AccessIO: Unexpected error while deleting object " + e.getMessage());
             }
             throw new IOException("Failed to delete file", e);
         }
     }
-    
+
     @Override
     public void closeInputStream() {
         try {
             ResponseInputStream<GetObjectResponse> responseInputStream = (ResponseInputStream<GetObjectResponse>) getInputStream();
-            if(responseInputStream!= null && responseInputStream.available()>0) {
+            if (responseInputStream != null && responseInputStream.available() > 0) {
                 responseInputStream.abort();
             }
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             errorMessage = e.getLocalizedMessage();
         }
         super.closeInputStream();
@@ -1577,11 +1643,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             HeadObjectResponse headObjectResponse = s3ReadClient.headObject(headObjectRequest).get();
             return headObjectResponse.contentLength();
-        } catch (InterruptedException | ExecutionException e) {
+        }
+        catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 throw new IOException("Cannot get S3 object " + key + " (" + s3e.getMessage() + ")", s3e);
-            } else {
+            }
+            else {
                 throw new IOException("Unexpected error while retrieving S3 object metadata", e);
             }
         }
@@ -1589,6 +1657,6 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
     public static String getNewIdentifier(String driverId) {
         return driverId + DataAccess.SEPARATOR + getConfigParamForDriver(driverId, BUCKET_NAME) + ":"
-                + FileUtil.generateStorageIdentifier();
+            + FileUtil.generateStorageIdentifier();
     }
 }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -355,10 +355,6 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 throw new IOException("Failed to get InputStream for S3 Object " + key, e);
             }
         }
-        if (super.getInputStream() == null) {
-            throw new IOException("Cannot get InputStream for S3 Object" + key);
-        }
-
         setChannel(Channels.newChannel(super.getInputStream()));
 
         return super.getInputStream();
@@ -461,7 +457,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 setSize(filesize);
             }
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while saving InputStream to S3 Object " + key, e);
+        }
+        catch (ExecutionException e) {
             String failureMsg = e.getMessage();
             if (failureMsg == null) {
                 failureMsg = "S3AccessIO: Unknown exception occurred while uploading a file into S3 Storage.";
@@ -491,7 +491,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             s3WriteClient.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
             // the result
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while deleting S3 Object " + key, e);
+        }
+        catch (ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
             throw new IOException("Failed to delete storage location " + getStorageLocation(), e);
         }
@@ -530,7 +534,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // the result
             return true;
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3AccessIO: Interrupted while checking if auxiliary object is cached: " + auxItemTag, e);
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 // Object doesn't exist
                 return false;
@@ -563,7 +571,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // result
             return headObjectResponse.contentLength();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3AccessIO: Interrupted while getting size of auxiliary object: " + auxItemTag, e);
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 // Object doesn't exist
                 logger.warning("Auxiliary object not found: " + destinationKey);
@@ -590,7 +602,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             s3WriteClient.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
             // the result
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
+            throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
+        }
+        catch (ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to backup original auxiliary object", e);
         }
@@ -607,7 +624,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // the result
             deleteAuxObject(auxItemTag);
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
+            throw new IOException("S3AccessIO: Unable to revert backup auxiliary object", e);
+        }
+        catch (ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.revertBackupAsAux: " + e.getMessage());
             throw new IOException("S3AccessIO: Unable to revert backup auxiliary object", e);
         }
@@ -626,7 +648,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             s3WriteClient.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
             // .get() to wait for the result
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
+            throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
+        }
+        catch (ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
             throw new IOException("S3AccessIO: Failed to save path as an auxiliary object.", e);
         }
@@ -652,7 +679,16 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 s3WriteClient.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
                 // .get() to wait for the result
             }
-            catch (InterruptedException | ExecutionException e) {
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                String failureMsg = e.getMessage();
+
+                if (failureMsg == null) {
+                    failureMsg = "S3AccessIO: Exception occurred while saving a local InputStream as S3Object";
+                }
+                throw new IOException(failureMsg, e);
+            }
+            catch (ExecutionException e) {
                 String failureMsg = e.getMessage();
 
                 if (failureMsg == null) {
@@ -700,7 +736,16 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // Use the async client to put the object
             s3WriteClient.putObject(putObjectRequest, requestBody).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            String failureMsg = e.getMessage();
+
+            if (failureMsg == null) {
+                failureMsg = "S3AccessIO: Exception occurred while saving a local InputStream as S3Object";
+            }
+            throw new IOException(failureMsg, e);
+        }
+        catch (ExecutionException e) {
             String failureMsg = e.getMessage();
 
             if (failureMsg == null) {
@@ -762,7 +807,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             listObjectsResponse = s3ReadClient.listObjectsV2(listObjectsReqManual).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3 listAuxObjects: failed to get a listing for " + prefix, e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("S3 listAuxObjects: failed to get a listing for " + prefix, e);
         }
 
@@ -789,7 +838,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 }
             }
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3AccessIO: Failed to get aux objects for listing.", e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to get aux objects for listing.", e);
         }
 
@@ -815,7 +868,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             s3WriteClient.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
             // for the result
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
+            throw new IOException("Failed to delete auxiliary object", e);
+        }
+        catch (ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
             throw new IOException("Failed to delete auxiliary object", e);
         }
@@ -843,7 +901,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             while (listResponse.isTruncated());
 
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3AccessIO: Failed to get aux objects for listing to delete.", e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to get aux objects for listing to delete.", e);
         }
 
@@ -863,7 +925,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             s3WriteClient.deleteObjects(deleteRequest).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3AccessIO: Failed to delete one or more auxiliary objects.", e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to delete one or more auxiliary objects.", e);
         }
     }
@@ -912,7 +978,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             s3ReadClient.headObject(headObjectRequest).get();
             return true;
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("Caught an exception in S3AccessIO.exists(): " + e.getMessage());
+            return false;
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 // Object does not exist
                 return false;
@@ -948,7 +1019,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             }
             return null;
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("Caught an exception in S3AccessIO.getAuxFileAsInputStream(): " + e.getMessage());
+            throw new IOException("Failed to get auxiliary file as input stream", e);
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
                 logger.fine("S3AccessIO.getAuxFileAsInputStream(): Object not found (not cached?): " + e.getMessage());
                 return null;
@@ -1402,7 +1478,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // tags and get charged for the operations
             s3WriteClient.deleteObjectTagging(deleteObjectTaggingRequest).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.severe("Unexpected error while removing temp tag: " + e.getMessage());
+            throw new IOException("Failed to remove temp tag", e);
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 if (s3e.statusCode() == 501) {
@@ -1484,7 +1565,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             s3Client.completeMultipartUpload(completeMultipartUploadRequest).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Failed to complete multipart upload", e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("Failed to complete multipart upload", e);
         }
     }
@@ -1547,7 +1632,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             listObjectsResponse = s3ReadClient.listObjectsV2(listObjectsReqManual).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3 listObjects: failed to get a listing for " + prefix, e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("S3 listObjects: failed to get a listing for " + prefix, e);
         }
 
@@ -1574,7 +1663,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 }
             }
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("S3AccessIO: Failed to get objects for listing.", e);
+        }
+        catch (ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to get objects for listing.", e);
         }
 
@@ -1601,7 +1694,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         try {
             s3WriteClient.deleteObject(deleteObjectRequest).get();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warning("S3AccessIO: Unexpected error while deleting object " + e.getMessage());
+            throw new IOException("Failed to delete file", e);
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 logger.warning("S3AccessIO: Unable to delete object " + s3e.getMessage());
@@ -1648,7 +1746,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             HeadObjectResponse headObjectResponse = s3ReadClient.headObject(headObjectRequest).get();
             return headObjectResponse.contentLength();
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Unexpected error while retrieving S3 object metadata", e);
+        }
+        catch (ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
                 throw new IOException("Cannot get S3 object " + key + " (" + s3e.getMessage() + ")", s3e);

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/S3AccessIO.java
@@ -107,9 +107,9 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     static final String PROFILE = "profile";
 
     private boolean mainDriver = true;
-    boolean s3pathStyleAccess = false;
 
-    private static HashMap<String, S3AsyncClient> driverClientMap = new HashMap<String, S3AsyncClient>();
+    private static HashMap<String, S3AsyncClient> driverDownloadClientMap = new HashMap<String, S3AsyncClient>();
+    private static HashMap<String, S3AsyncClient> driverUploadClientMap = new HashMap<String, S3AsyncClient>();
     private static HashMap<String, S3Presigner> driverPresignerMap = new HashMap<String, S3Presigner>();
     private static HashMap<String, AwsCredentialsProvider> driverCredentialsProviderMap = new HashMap<String, AwsCredentialsProvider>();
     private static HashMap<String, S3TransferManager> driverTMMap = new HashMap<String, S3TransferManager>();
@@ -122,7 +122,8 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             bucketName = getBucketName(driverId);
             minPartSize = getMinPartSize(driverId);
             credentialsProvider = getCredentialsProvider(driverId);
-            s3 = getClient(driverId);
+            s3ReadClient = getReadClient(driverId);
+            s3WriteClient = getWriteClient(driverId);
             tm = getTransferManager(driverId);
             s3Presigner = getPresigner(driverId);
             endpoint = getConfigParam(CUSTOM_ENDPOINT_URL, "");
@@ -152,10 +153,12 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         super(dvObject, req, driverId);
         bucketName = getBucketName(driverId);
         this.setIsLocalFile(false);
-        this.s3 = s3client;
+        this.s3ReadClient = s3client;
+        this.s3WriteClient = s3client;
     }
 
-    private S3AsyncClient s3 = null;
+    private S3AsyncClient s3ReadClient = null;
+    private S3AsyncClient s3WriteClient = null;
     private S3Presigner s3Presigner = null;
     private AwsCredentialsProvider credentialsProvider;
     private S3TransferManager tm = null;
@@ -167,7 +170,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
     @Override
     public void open(DataAccessOption... options) throws IOException {
-        if (s3 == null) {
+        if (s3ReadClient == null || s3WriteClient == null) {
             throw new IOException("ERROR: s3 not initialised. ");
         }
 
@@ -190,7 +193,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 this.setNoVarHeader(true);
             }
 
-            if (storageIdentifier == null || "".equals(storageIdentifier)) {
+            if (storageIdentifier == null || storageIdentifier.isEmpty()) {
                 throw new FileNotFoundException("Data Access: No local storage identifier defined for this datafile.");
             }
 
@@ -269,7 +272,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 while (retries > 0) {
                     try {
                         // Since s3 is an S3AsyncClient, we need to call .get() to wait for the result.
-                        HeadObjectResponse headObjectResponse = s3
+                        HeadObjectResponse headObjectResponse = s3ReadClient
                                 .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()).get();
                         contentLength = headObjectResponse.contentLength();
                         if (retries != 20) {
@@ -306,14 +309,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         if (super.getInputStream() == null) {
             ResponseInputStream<GetObjectResponse> responseInputStream;
             try {
-                responseInputStream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
+                responseInputStream = s3ReadClient.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build(),
                         AsyncResponseTransformer.toBlockingInputStream()).get(); // Since s3 is an S3AsyncClient, we
                                                                                  // need to call .get() to wait for the
                                                                                  // result
                 setInputStream(responseInputStream);
             } catch (InterruptedException | ExecutionException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                logger.warning("Caught an exception in S3AccessIO.getInputStream(): " + e.getMessage());
             }
         }
         if (super.getInputStream() == null) {
@@ -358,8 +360,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
                 newFileSize = Files.size(fileSystemPath);
             } catch (Exception e) {
-                logger.warning(e.getMessage());
-                e.printStackTrace();
+                logger.warning("Caught an exception in S3AccessIO.savePath(): " + e.getMessage());
                 throw new IOException(
                         "S3AccessIO: Exception occurred while uploading a local file into S3Object " + key, e);
             }
@@ -408,10 +409,10 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 asyncRequestBody = AsyncRequestBody.fromFile(tempFile);
             }
 
-            s3.putObject(putObjectRequestBuilder.build(), asyncRequestBody).get();
+            s3WriteClient.putObject(putObjectRequestBuilder.build(), asyncRequestBody).get();
 
             if (filesize == null) {
-                HeadObjectResponse headObjectResponse = s3
+                HeadObjectResponse headObjectResponse = s3ReadClient
                         .headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()).get();
                 setSize(headObjectResponse.contentLength());
             } else {
@@ -443,7 +444,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         // - ?)
         try {
             DeleteObjectRequest deleteObjRequest = DeleteObjectRequest.builder().bucket(bucketName).key(key).build();
-            s3.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
+            s3WriteClient.deleteObject(deleteObjRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
                                                      // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.delete(): " + e.getMessage());
@@ -480,7 +481,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucketName).key(destinationKey)
                     .build();
 
-            s3.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
+            s3ReadClient.headObject(headObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
                                                     // the result
             return true;
         } catch (InterruptedException | ExecutionException e) {
@@ -498,7 +499,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         open();
         String destinationKey = getDestinationKey(auxItemTag);
         try {
-            HeadObjectResponse headObjectResponse = s3
+            HeadObjectResponse headObjectResponse = s3ReadClient
                     .headObject(HeadObjectRequest.builder().bucket(bucketName).key(destinationKey).build()).get(); // Since
                                                                                                                    // s3
                                                                                                                    // is
@@ -539,7 +540,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder().sourceBucket(bucketName).sourceKey(key)
                     .destinationBucket(bucketName).destinationKey(destinationKey).build();
 
-            s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
+            s3WriteClient.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
                                                     // the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.backupAsAux: " + e.getMessage());
@@ -554,7 +555,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder().sourceBucket(bucketName)
                     .sourceKey(destinationKey).destinationBucket(bucketName).destinationKey(key).build();
 
-            s3.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
+            s3WriteClient.copyObject(copyObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait for
                                                     // the result
             deleteAuxObject(auxItemTag);
         } catch (InterruptedException | ExecutionException e) {
@@ -573,7 +574,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucketName).key(destinationKey)
                     .build();
             AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromFile(fileSystemPath);
-            s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
+            s3WriteClient.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
                                                                     // .get() to wait for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("Caught an exception in S3AccessIO.savePathAsAux(): " + e.getMessage());
@@ -597,7 +598,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 AsyncRequestBody asyncRequestBody = AsyncRequestBody.fromInputStream(inputStream, filesize,
                         executorService);
 
-                s3.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
+                s3WriteClient.putObject(putObjectRequest, asyncRequestBody).get(); // Since s3 is an S3AsyncClient, we need to call
                                                                         // .get() to wait for the result
             } catch (InterruptedException | ExecutionException e) {
                 String failureMsg = e.getMessage();
@@ -652,7 +653,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             AsyncRequestBody requestBody = AsyncRequestBody.fromFile(tempFile);
 
             // Use the async client to put the object
-            s3.putObject(putObjectRequest, requestBody).get();
+            s3WriteClient.putObject(putObjectRequest, requestBody).get();
         } catch (InterruptedException | ExecutionException e) {
             String failureMsg = e.getMessage();
 
@@ -710,7 +711,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
         ListObjectsV2Response listObjectsResponse = null;
         try {
-            listObjectsResponse = s3.listObjectsV2(listObjectsReqManual).get();
+            listObjectsResponse = s3ReadClient.listObjectsV2(listObjectsReqManual).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3 listAuxObjects: failed to get a listing for " + prefix, e);
         }
@@ -728,7 +729,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 ListObjectsV2Request nextReq = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
                         .continuationToken(nextContinuationToken).build();
 
-                ListObjectsV2Response nextResponse = s3.listObjectsV2(nextReq).get();
+                ListObjectsV2Response nextResponse = s3ReadClient.listObjectsV2(nextReq).get();
                 if (nextResponse != null) {
                     storedAuxFilesSummary.addAll(nextResponse.contents());
                     nextContinuationToken = nextResponse.nextContinuationToken();
@@ -759,7 +760,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder().bucket(bucketName)
                     .key(destinationKey).build();
 
-            s3.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
+            s3WriteClient.deleteObject(deleteObjectRequest).get(); // Since s3 is an S3AsyncClient, we need to call .get() to wait
                                                         // for the result
         } catch (InterruptedException | ExecutionException e) {
             logger.warning("S3AccessIO: Unable to delete object: " + e.getMessage());
@@ -781,7 +782,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             ListObjectsV2Response listResponse;
             do {
-                listResponse = s3.listObjectsV2(listRequest).get();
+                listResponse = s3ReadClient.listObjectsV2(listRequest).get();
                 storedAuxFilesSummary.addAll(listResponse.contents());
 
                 listRequest = listRequest.toBuilder().continuationToken(listResponse.nextContinuationToken()).build();
@@ -805,7 +806,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
         logger.fine("Trying to delete auxiliary files...");
         try {
-            s3.deleteObjects(deleteRequest).get();
+            s3WriteClient.deleteObjects(deleteRequest).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3AccessIO: Failed to delete one or more auxiliary objects.", e);
         }
@@ -849,7 +850,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucketName).key(destinationKey)
                     .build();
 
-            s3.headObject(headObjectRequest).get();
+            s3ReadClient.headObject(headObjectRequest).get();
             return true;
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof NoSuchKeyException) {
@@ -880,7 +881,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName).key(destinationKey)
                     .build();
 
-            ResponseInputStream<GetObjectResponse> s3ObjectContent = s3
+            ResponseInputStream<GetObjectResponse> s3ObjectContent = s3ReadClient
                     .getObject(getObjectRequest, AsyncResponseTransformer.toBlockingInputStream()).get();
             if (s3ObjectContent != null) {
                 return s3ObjectContent;
@@ -987,11 +988,11 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
      * @param auxiliaryFileName (optional) - file name, if different from the main
      *                          file label.
      * @return redirect url
-     * @throws IOException.
+     * @throws IOException
      */
     public String generateTemporaryDownloadUrl(String auxiliaryTag, String auxiliaryType, String auxiliaryFileName)
             throws IOException {
-        if (s3 == null) {
+        if (s3ReadClient == null || s3WriteClient == null) {
             throw new IOException("ERROR: s3 not initialised. ");
         }
         if (dvObject instanceof DataFile) {
@@ -1048,7 +1049,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
     }
 
     private String generateTemporaryS3UploadUrl(String key, Date expiration) throws IOException {
-        if (s3 == null) {
+        if (s3ReadClient == null || s3WriteClient == null) {
             throw new IOException("ERROR: s3 not initialised. ");
         }
 
@@ -1112,7 +1113,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                     .builder().bucket(bucketName).key(key);
 
             // Use the existing s3 async client for the createMultipartUpload operation
-            CompletableFuture<CreateMultipartUploadResponse> createMultipartUploadFuture = s3.createMultipartUpload(createMultipartUploadRequestBuilder.build());
+            CompletableFuture<CreateMultipartUploadResponse> createMultipartUploadFuture = s3WriteClient.createMultipartUpload(createMultipartUploadRequestBuilder.build());
             CreateMultipartUploadResponse createMultipartUploadResponse = createMultipartUploadFuture.join();
             String uploadId = createMultipartUploadResponse.uploadId();
 
@@ -1195,16 +1196,24 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         } else {
             // building a TransferManager instance to support multipart uploading for files
             // over 4gb.
-            S3TransferManager manager = S3TransferManager.builder().s3Client(getClient(driverId)).build();
+            S3TransferManager manager = S3TransferManager.builder().s3Client(getWriteClient(driverId)).build();
             driverTMMap.put(driverId, manager);
             return manager;
         }
     }
 
-    private static S3AsyncClient getClient(String driverId) {
+    private static S3AsyncClient getReadClient(String driverId) {
+        return getClient(driverId, false);
+    }
 
-        if (driverClientMap.containsKey(driverId)) {
-            return driverClientMap.get(driverId);
+    private static S3AsyncClient getWriteClient(String driverId) {
+        return getClient(driverId, true);
+    }
+
+    private static S3AsyncClient getClient(String driverId, boolean upload) {
+        HashMap<String, S3AsyncClient> clientMap = upload ? driverUploadClientMap : driverDownloadClientMap;
+        if (clientMap.containsKey(driverId)) {
+            return clientMap.get(driverId);
         } else {
             // Create a builder for the S3AsyncClient
             S3AsyncClientBuilder s3CB = S3AsyncClient.builder().requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
@@ -1216,12 +1225,16 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // Apply the custom HTTP client to the S3AsyncClientBuilder
             s3CB.httpClientBuilder(httpClientBuilder);
 
-            // Enable multipart and configure it to be used if the file is larger than minPartSize.
-            s3CB.multipartEnabled(true);
-            long minPartSize = getMinPartSize(driverId);
-            s3CB.multipartConfiguration(MultipartConfiguration.builder()
-                .thresholdInBytes(minPartSize)
-                .minimumPartSizeInBytes(minPartSize).build());
+            if (upload) {
+                // Enable multipart and configure it to be used if the file is larger than minPartSize.
+                s3CB.multipartEnabled(true);
+                long minPartSize = getMinPartSize(driverId);
+                s3CB.multipartConfiguration(MultipartConfiguration.builder()
+                    .thresholdInBytes(minPartSize)
+                    .minimumPartSizeInBytes(minPartSize).build());
+            } else {
+                s3CB.multipartEnabled(false);
+            }
 
             // Configure endpoint and region
             String s3CEUrl = getConfigParamForDriver(driverId, CUSTOM_ENDPOINT_URL, "");
@@ -1247,9 +1260,13 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
             // Build the client
             S3AsyncClient client = s3CB.build();
-            driverClientMap.put(driverId, client);
+            clientMap.put(driverId, client);
             return client;
         }
+    }
+
+    private static S3AsyncClient getClient(String driverId) {
+        return getWriteClient(driverId);
     }
 
     private static S3Presigner getPresigner(String driverId) {
@@ -1331,7 +1348,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
             // way to get rid of that one tag
             // Otherwise you have to get tags, remove the one you don't want and post new
             // tags and get charged for the operations
-            s3.deleteObjectTagging(deleteObjectTaggingRequest).get();
+            s3WriteClient.deleteObjectTagging(deleteObjectTaggingRequest).get();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
@@ -1464,7 +1481,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
 
         ListObjectsV2Response listObjectsResponse = null;
         try {
-            listObjectsResponse = s3.listObjectsV2(listObjectsReqManual).get();
+            listObjectsResponse = s3ReadClient.listObjectsV2(listObjectsReqManual).get();
         } catch (InterruptedException | ExecutionException e) {
             throw new IOException("S3 listObjects: failed to get a listing for " + prefix, e);
         }
@@ -1482,7 +1499,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 ListObjectsV2Request nextReq = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix)
                         .continuationToken(nextContinuationToken).build();
 
-                ListObjectsV2Response nextResponse = s3.listObjectsV2(nextReq).get();
+                ListObjectsV2Response nextResponse = s3ReadClient.listObjectsV2(nextReq).get();
                 if (nextResponse != null) {
                     storedFilesSummary.addAll(nextResponse.contents());
                     nextContinuationToken = nextResponse.nextContinuationToken();
@@ -1515,7 +1532,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
                 .key(prefix + fileName).build();
 
         try {
-            s3.deleteObject(deleteObjectRequest).get();
+            s3WriteClient.deleteObject(deleteObjectRequest).get();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {
                 S3Exception s3e = (S3Exception) e.getCause();
@@ -1558,7 +1575,7 @@ public class S3AccessIO<T extends DvObject> extends StorageIO<T> {
         HeadObjectRequest headObjectRequest = HeadObjectRequest.builder().bucket(bucketName).key(key).build();
 
         try {
-            HeadObjectResponse headObjectResponse = s3.headObject(headObjectRequest).get();
+            HeadObjectResponse headObjectResponse = s3ReadClient.headObject(headObjectRequest).get();
             return headObjectResponse.contentLength();
         } catch (InterruptedException | ExecutionException e) {
             if (e.getCause() instanceof S3Exception) {

--- a/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
+++ b/src/main/java/propertyFiles/MimeTypeDetectionByFileExtension.properties
@@ -41,3 +41,5 @@ Rmd=text/x-r-notebook
 rb=text/x-ruby-script
 dag=text/x-dagman
 glb=model/gltf-binary
+css=text/css
+

--- a/src/main/webapp/dataset.xhtml
+++ b/src/main/webapp/dataset.xhtml
@@ -250,6 +250,7 @@
                                                                             <h:outputFormat value="#{bundle['dataset.accessBtn.download.size']}">
                                                                                 <f:param value="#{sizeOfDataset}" />
                                                                             </h:outputFormat>
+                                                                            <f:actionListener binding="#{DatasetPage.setTermsGuestbookPopupAction(bundle.download)}"/>
                                                                         </p:commandLink>
                                                                     </li>
                                                                     <!-- Archival Format too big -->


### PR DESCRIPTION
Fixes DD-2271

# Description of changes
* Split the `S3AsyncClient` in `S3AccessIO` in two separated clients: one for read and one for write actions, with multipart enabled on the write-client and disabled on the read-client. In many calls it does not really whether multipart is enabled, but for readability I stuck to the logic that read actions are performed by the read client and write actions by the write client.
* Fixed some problems found by AI code review:
   * potential concurrency problems with the static maps
   * handling of InterruptedException
   * replaced syserr with logging.



# Notify
@DANS-KNAW/core-systems
