### PR TITLE
DD-2317 split table termsofuseandaccess into termsofaccess and termsofuseorlicense

### DIFF
--- a/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
+++ b/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS TERMSOFUSEORLICENSE (
     DEPOSITORREQUIREMENTS TEXT,
     DISCLAIMER TEXT,
     FILEACCESSREQUEST BOOLEAN,
-    LICENSE_ID BIGINT,
+    LICENSE_ID BIGINT REFERENCES LICENSE(ID),
     RESTRICTIONS TEXT,
     SPECIALPERMISSIONS TEXT,
     TERMSOFUSE TEXT,
@@ -45,10 +45,6 @@ ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT;
 
 DO $$
     BEGIN
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_termsofuseorlicense_license_id') THEN
-            ALTER TABLE termsofuseorlicense ADD CONSTRAINT fk_termsofuseorlicense_license_id foreign key (license_id) REFERENCES license(id);
-        END IF;
-
         IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
             UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
             ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;

--- a/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
+++ b/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
@@ -1,0 +1,90 @@
+CREATE TABLE IF NOT EXISTS TERMSOFACCESS (
+    ID  SERIAL NOT NULL,
+    AVAILABILITYSTATUS TEXT,
+    CONTACTFORACCESS TEXT,
+    CONFIDENTIALITYDECLARATION TEXT,
+    DATAACCESSPLACE TEXT,
+    ORIGINALARCHIVE TEXT,
+    SIZEOFCOLLECTION TEXT,
+    STUDYCOMPLETION TEXT,
+    TERMSOFACCESS TEXT,
+    FILEACCESSREQUEST BOOLEAN,
+    PRIMARY KEY (ID)
+);
+
+CREATE TABLE IF NOT EXISTS TERMSOFUSEORLICENSE (
+    ID  SERIAL NOT NULL,
+    CITATIONREQUIREMENTS TEXT,
+    CONDITIONS TEXT,
+    CONFIDENTIALITYDECLARATION TEXT,
+    DEPOSITORREQUIREMENTS TEXT,
+    DISCLAIMER TEXT,
+    FILEACCESSREQUEST BOOLEAN,
+    LICENSE_ID BIGINT,
+    RESTRICTIONS TEXT,
+    SPECIALPERMISSIONS TEXT,
+    TERMSOFUSE TEXT,
+    PRIMARY KEY (ID)
+);
+
+INSERT INTO termsofuseorlicense (id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse)
+SELECT id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse
+FROM termsofuseandaccess WHERE id NOT IN (SELECT id FROM termsofuseorlicense);
+
+INSERT INTO termsofaccess (id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest)
+SELECT id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest
+FROM termsofuseandaccess WHERE id NOT IN (SELECT id FROM termsofaccess);
+
+ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT;
+ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS  default_termsofuseorlicense_id BIGINT;
+
+ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT;
+ALTER TABLE template ADD COLUMN IF NOT EXISTS  default_termsofuseorlicense_id BIGINT;
+
+ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT;
+
+DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_termsofuseorlicense_license_id') THEN
+            ALTER TABLE termsofuseorlicense ADD CONSTRAINT fk_termsofuseorlicense_license_id foreign key (license_id) REFERENCES license(id);
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
+            UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+            ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
+            ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
+        END IF;
+
+        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
+            UPDATE template SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+            ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
+            ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
+        END IF;
+    END
+$$;
+--------------------------------------------------------------------------
+-- Perhaps less code breaks with the view, no updates are possible though.
+--------------------------------------------------------------------------
+DROP TABLE IF EXISTS termsofuseandaccess;
+CREATE VIEW termsofuseandaccess AS
+SELECT
+ l.id,
+ a.availabilitystatus,
+ l.citationrequirements,
+ l.conditions,
+ l.confidentialitydeclaration,
+ a.contactforaccess,
+ a.dataaccessplace,
+ l.depositorrequirements,
+ l.disclaimer,
+ l.fileaccessrequest,
+ a.originalarchive,
+ l.restrictions,
+ a.sizeofcollection,
+ l.specialpermissions,
+ a.studycompletion,
+ a.termsofaccess,
+ l.termsofuse,
+ l.license_id
+FROM termsofaccess a
+LEFT JOIN termsofuseorlicense l ON a.id = l.id;

--- a/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
+++ b/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
@@ -39,7 +39,7 @@ ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFE
 ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
 ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
-ALTER TABLE template ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
 ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
@@ -55,13 +55,13 @@ BEGIN
     ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
 
     IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
-        UPDATE template SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+        UPDATE template SET termsofaccess_id = termsofuseandaccess_id, termsofuseorlicense_id = termsofuseandaccess_id;
         ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
     ELSE
         RAISE NOTICE 'Column termsofuseandaccess_id already dropped';
     END IF;
     ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
-    ALTER TABLE template ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
+    ALTER TABLE template ALTER COLUMN termsofuseorlicense_id SET NOT NULL;
 
     -- assumption: if one row is migrated, all are migrated
     IF EXISTS (SELECT 1 FROM termsofuseandaccess) AND

--- a/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
+++ b/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
@@ -29,42 +29,56 @@ CREATE TABLE IF NOT EXISTS TERMSOFUSEORLICENSE (
 
 INSERT INTO termsofuseorlicense (id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse)
 SELECT id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse
-FROM termsofuseandaccess WHERE id NOT IN (SELECT id FROM termsofuseorlicense);
+FROM termsofuseandaccess a WHERE NOT EXISTS (select 1 FROM termsofuseorlicense t WHERE t.id = a.id);
 
 INSERT INTO termsofaccess (id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest)
 SELECT id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest
-FROM termsofuseandaccess WHERE id NOT IN (SELECT id FROM termsofaccess);
+FROM termsofuseandaccess a WHERE NOT EXISTS (select 1 FROM termsofaccess t WHERE t.id = a.id);
 
 ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
 ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
 ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
-ALTER TABLE template ADD COLUMN IF NOT EXISTS  default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+ALTER TABLE template ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
-ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT;
+ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
 DO $$
-    BEGIN
-        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
-            UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
-            ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
-            ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
-            ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
-        END IF;
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
+        UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+        ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
+    ELSE
+        RAISE NOTICE 'Column termsofuseandaccess_id already dropped.';
+    END IF;
+    ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
+    ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
 
-        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
-            UPDATE template SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
-            ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
-            ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
-            ALTER TABLE template ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
-        END IF;
-    END
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
+        UPDATE template SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+        ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
+    ELSE
+        RAISE NOTICE 'Column termsofuseandaccess_id already dropped';
+    END IF;
+    ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
+    ALTER TABLE template ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
+
+    -- assumption: if one row is migrated, all are migrated
+    IF EXISTS (SELECT 1 FROM termsofuseandaccess) AND
+       EXISTS (SELECT 1 FROM termsofuseorlicense) AND
+       NOT EXISTS (SELECT 1 FROM pg_views WHERE viewname='termsofuseandaccess')
+    THEN
+        DROP TABLE IF EXISTS termsofuseandaccess;
+    ELSE
+        RAISE NOTICE 'Not dropping termsofuseandaccess table, it is a view or not yet migrated.';
+    END IF;
+END
 $$;
+
 ---------------------------------------------------------------------------------------------
 -- Perhaps less code breaks with the view during development, no updates are possible though.
 ---------------------------------------------------------------------------------------------
-DROP TABLE IF EXISTS termsofuseandaccess;
-CREATE VIEW termsofuseandaccess AS
+CREATE OR REPLACE VIEW termsofuseandaccess AS
 SELECT
  l.id,
  a.availabilitystatus,

--- a/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
+++ b/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql
@@ -35,11 +35,11 @@ INSERT INTO termsofaccess (id, availabilitystatus, contactforaccess, confidentia
 SELECT id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest
 FROM termsofuseandaccess WHERE id NOT IN (SELECT id FROM termsofaccess);
 
-ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT;
-ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS  default_termsofuseorlicense_id BIGINT;
+ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
+ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
-ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT;
-ALTER TABLE template ADD COLUMN IF NOT EXISTS  default_termsofuseorlicense_id BIGINT;
+ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
+ALTER TABLE template ADD COLUMN IF NOT EXISTS  default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
 
 ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT;
 
@@ -49,18 +49,20 @@ DO $$
             UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
             ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
             ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
+            ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
         END IF;
 
         IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
             UPDATE template SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
             ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
             ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
+            ALTER TABLE template ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
         END IF;
     END
 $$;
---------------------------------------------------------------------------
--- Perhaps less code breaks with the view, no updates are possible though.
---------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------
+-- Perhaps less code breaks with the view during development, no updates are possible though.
+---------------------------------------------------------------------------------------------
 DROP TABLE IF EXISTS termsofuseandaccess;
 CREATE VIEW termsofuseandaccess AS
 SELECT


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

On the DANS VM  pre-provisioned-dev_dataversenl_v6.9-PATCH-7_2026-03-05.box

- One of:
  - Create a template and a dataset (from the template?) with a restricted file and fill all fields on the terms tab and save the changes for a fresh base box.

        pg_dump --clean -U dvnuser dvndb > /vagrant/shared/DD-2317-file-license-test.sql

  - Repeat the test on a fresh base-box with previously created test datasets:

        psql dvndb < /vagrant/shared/DD-2317-file-license-test.sql 
        curl http://localhost:8080/api/admin/index

- List the content for the table _termsofuseandaccess_.
- As user `postgres`:

      psql --echo-all dvndb < /vagrant/external/dataverse/src/main/resources/db/migration/V6.9__DD-2317-file-licenses.sql

- List the content for the tables _termsofuseorlicense_ and _termsofaccess_.
- _termsofuseandaccess_ should now be a (temporary!) view with the same content as the table used to have.
For the view to be of any use in the future, the join should be via the id's in the _datasetverion_ and _template_ tables.
- [x] check the changed ID's in the tables _datasetversion_ and _template_.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
