### PR TITLE
DD-2317: split table TermsOfUseAndAccess

### DIFF
--- a/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql
+++ b/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql
@@ -1,6 +1,6 @@
 DO $$
 BEGIN
-    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='termsofaccess') THEN
         CREATE TABLE TERMSOFACCESS (
                                        ID  SERIAL NOT NULL,
                                        AVAILABILITYSTATUS TEXT,
@@ -29,11 +29,6 @@ BEGIN
                                        PRIMARY KEY (ID)
         );
 
-        GRANT SELECT, INSERT, UPDATE, DELETE ON termsofaccess TO dvnuser;
-        GRANT SELECT, INSERT, UPDATE, DELETE ON termsofuseorlicense TO dvnuser;
-        GRANT USAGE, SELECT ON SEQUENCE termsofaccess_id_seq TO dvnuser;
-        GRANT USAGE, SELECT ON SEQUENCE termsofuseorlicense_id_seq TO dvnuser;
-
         INSERT INTO termsofuseorlicense (id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse)
         SELECT id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse
         FROM termsofuseandaccess;
@@ -60,6 +55,11 @@ BEGIN
         ALTER TABLE template ALTER COLUMN termsofuseorlicense_id SET NOT NULL;
 
         DROP TABLE termsofuseandaccess;
+
+        GRANT SELECT, INSERT, UPDATE, DELETE ON termsofaccess TO dvnuser;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON termsofuseorlicense TO dvnuser;
+        GRANT USAGE, SELECT ON SEQUENCE termsofaccess_id_seq TO dvnuser;
+        GRANT USAGE, SELECT ON SEQUENCE termsofuseorlicense_id_seq TO dvnuser;
     END IF;
 END
 $$;

--- a/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql
+++ b/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql
@@ -1,0 +1,81 @@
+CREATE TABLE IF NOT EXISTS TERMSOFACCESS (
+                                             ID  SERIAL NOT NULL,
+                                             AVAILABILITYSTATUS TEXT,
+                                             CONTACTFORACCESS TEXT,
+                                             CONFIDENTIALITYDECLARATION TEXT,
+                                             DATAACCESSPLACE TEXT,
+                                             ORIGINALARCHIVE TEXT,
+                                             SIZEOFCOLLECTION TEXT,
+                                             STUDYCOMPLETION TEXT,
+                                             TERMSOFACCESS TEXT,
+                                             FILEACCESSREQUEST BOOLEAN,
+                                             PRIMARY KEY (ID)
+    );
+
+CREATE TABLE IF NOT EXISTS TERMSOFUSEORLICENSE (
+                                                   ID  SERIAL NOT NULL,
+                                                   CITATIONREQUIREMENTS TEXT,
+                                                   CONDITIONS TEXT,
+                                                   CONFIDENTIALITYDECLARATION TEXT,
+                                                   DEPOSITORREQUIREMENTS TEXT,
+                                                   DISCLAIMER TEXT,
+                                                   FILEACCESSREQUEST BOOLEAN,
+                                                   LICENSE_ID BIGINT REFERENCES LICENSE(ID),
+                                                   RESTRICTIONS TEXT,
+                                                   SPECIALPERMISSIONS TEXT,
+                                                   TERMSOFUSE TEXT,
+                                                   PRIMARY KEY (ID)
+    );
+
+INSERT INTO termsofuseorlicense (id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse)
+SELECT id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse
+FROM termsofuseandaccess a WHERE NOT EXISTS (select 1 FROM termsofuseorlicense t WHERE t.id = a.id);
+
+INSERT INTO termsofaccess (id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest)
+SELECT id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest
+FROM termsofuseandaccess a WHERE NOT EXISTS (select 1 FROM termsofaccess t WHERE t.id = a.id);
+
+ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
+ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+
+ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
+ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+
+ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
+UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
+ELSE
+        RAISE NOTICE 'Column termsofuseandaccess_id already dropped.';
+END IF;
+ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
+ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
+
+IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
+UPDATE template SET termsofaccess_id = termsofuseandaccess_id, termsofuseorlicense_id = termsofuseandaccess_id;
+ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
+ELSE
+        RAISE NOTICE 'Column termsofuseandaccess_id already dropped';
+END IF;
+ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
+ALTER TABLE template ALTER COLUMN termsofuseorlicense_id SET NOT NULL;
+
+-- assumption: if one row is migrated, all are migrated
+IF EXISTS (SELECT 1 FROM termsofuseandaccess) AND
+       EXISTS (SELECT 1 FROM termsofuseorlicense) AND
+       NOT EXISTS (SELECT 1 FROM pg_views WHERE viewname='termsofuseandaccess')
+    THEN
+DROP TABLE IF EXISTS termsofuseandaccess;
+ELSE
+        RAISE NOTICE 'Not dropping termsofuseandaccess table, it is a view or not yet migrated.';
+END IF;
+END
+$$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON termsofaccess TO dvnuser;
+GRANT SELECT, INSERT, UPDATE, DELETE ON termsofuseorlicense TO dvnuser;
+GRANT USAGE, SELECT ON SEQUENCE termsofaccess_id_seq TO dvnuser;
+GRANT USAGE, SELECT ON SEQUENCE termsofuseorlicense_id_seq TO dvnuser;

--- a/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql
+++ b/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql
@@ -1,81 +1,65 @@
-CREATE TABLE IF NOT EXISTS TERMSOFACCESS (
-                                             ID  SERIAL NOT NULL,
-                                             AVAILABILITYSTATUS TEXT,
-                                             CONTACTFORACCESS TEXT,
-                                             CONFIDENTIALITYDECLARATION TEXT,
-                                             DATAACCESSPLACE TEXT,
-                                             ORIGINALARCHIVE TEXT,
-                                             SIZEOFCOLLECTION TEXT,
-                                             STUDYCOMPLETION TEXT,
-                                             TERMSOFACCESS TEXT,
-                                             FILEACCESSREQUEST BOOLEAN,
-                                             PRIMARY KEY (ID)
-    );
-
-CREATE TABLE IF NOT EXISTS TERMSOFUSEORLICENSE (
-                                                   ID  SERIAL NOT NULL,
-                                                   CITATIONREQUIREMENTS TEXT,
-                                                   CONDITIONS TEXT,
-                                                   CONFIDENTIALITYDECLARATION TEXT,
-                                                   DEPOSITORREQUIREMENTS TEXT,
-                                                   DISCLAIMER TEXT,
-                                                   FILEACCESSREQUEST BOOLEAN,
-                                                   LICENSE_ID BIGINT REFERENCES LICENSE(ID),
-                                                   RESTRICTIONS TEXT,
-                                                   SPECIALPERMISSIONS TEXT,
-                                                   TERMSOFUSE TEXT,
-                                                   PRIMARY KEY (ID)
-    );
-
-INSERT INTO termsofuseorlicense (id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse)
-SELECT id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse
-FROM termsofuseandaccess a WHERE NOT EXISTS (select 1 FROM termsofuseorlicense t WHERE t.id = a.id);
-
-INSERT INTO termsofaccess (id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest)
-SELECT id, availabilitystatus, contactforaccess, confidentialitydeclaration, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest
-FROM termsofuseandaccess a WHERE NOT EXISTS (select 1 FROM termsofaccess t WHERE t.id = a.id);
-
-ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
-ALTER TABLE datasetversion ADD COLUMN IF NOT EXISTS default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
-
-ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofaccess_id BIGINT REFERENCES termsofaccess(id);
-ALTER TABLE template ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
-
-ALTER TABLE filemetadata ADD COLUMN IF NOT EXISTS termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
-
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='datasetversion' and column_name='termsofuseandaccess_id') THEN
-UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
-ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
-ELSE
-        RAISE NOTICE 'Column termsofuseandaccess_id already dropped.';
-END IF;
-ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
-ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
+        CREATE TABLE TERMSOFACCESS (
+                                       ID  SERIAL NOT NULL,
+                                       AVAILABILITYSTATUS TEXT,
+                                       CONTACTFORACCESS TEXT,
+                                       DATAACCESSPLACE TEXT,
+                                       ORIGINALARCHIVE TEXT,
+                                       SIZEOFCOLLECTION TEXT,
+                                       STUDYCOMPLETION TEXT,
+                                       TERMSOFACCESS TEXT,
+                                       FILEACCESSREQUEST BOOLEAN,
+                                       PRIMARY KEY (ID)
+        );
 
-IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='template' and column_name='termsofuseandaccess_id') THEN
-UPDATE template SET termsofaccess_id = termsofuseandaccess_id, termsofuseorlicense_id = termsofuseandaccess_id;
-ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
-ELSE
-        RAISE NOTICE 'Column termsofuseandaccess_id already dropped';
-END IF;
-ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
-ALTER TABLE template ALTER COLUMN termsofuseorlicense_id SET NOT NULL;
+        CREATE TABLE TERMSOFUSEORLICENSE (
+                                       ID  SERIAL NOT NULL,
+                                       CITATIONREQUIREMENTS TEXT,
+                                       CONDITIONS TEXT,
+                                       CONFIDENTIALITYDECLARATION TEXT,
+                                       DEPOSITORREQUIREMENTS TEXT,
+                                       DISCLAIMER TEXT,
+                                       FILEACCESSREQUEST BOOLEAN,
+                                       LICENSE_ID BIGINT REFERENCES LICENSE(ID),
+                                       RESTRICTIONS TEXT,
+                                       SPECIALPERMISSIONS TEXT,
+                                       TERMSOFUSE TEXT,
+                                       PRIMARY KEY (ID)
+        );
 
--- assumption: if one row is migrated, all are migrated
-IF EXISTS (SELECT 1 FROM termsofuseandaccess) AND
-       EXISTS (SELECT 1 FROM termsofuseorlicense) AND
-       NOT EXISTS (SELECT 1 FROM pg_views WHERE viewname='termsofuseandaccess')
-    THEN
-DROP TABLE IF EXISTS termsofuseandaccess;
-ELSE
-        RAISE NOTICE 'Not dropping termsofuseandaccess table, it is a view or not yet migrated.';
-END IF;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON termsofaccess TO dvnuser;
+        GRANT SELECT, INSERT, UPDATE, DELETE ON termsofuseorlicense TO dvnuser;
+        GRANT USAGE, SELECT ON SEQUENCE termsofaccess_id_seq TO dvnuser;
+        GRANT USAGE, SELECT ON SEQUENCE termsofuseorlicense_id_seq TO dvnuser;
+
+        INSERT INTO termsofuseorlicense (id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse)
+        SELECT id, citationrequirements, conditions, confidentialitydeclaration, depositorrequirements, disclaimer, fileaccessrequest, license_id, restrictions, specialpermissions, termsofuse
+        FROM termsofuseandaccess;
+
+        INSERT INTO termsofaccess (id, availabilitystatus, contactforaccess, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest)
+        SELECT id, availabilitystatus, contactforaccess, dataaccessplace, originalarchive, sizeofcollection, studycompletion, termsofaccess, fileaccessrequest
+        FROM termsofuseandaccess;
+
+        ALTER TABLE datasetversion ADD COLUMN termsofaccess_id BIGINT REFERENCES termsofaccess(id);
+        ALTER TABLE datasetversion ADD COLUMN default_termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+        ALTER TABLE template ADD COLUMN termsofaccess_id BIGINT REFERENCES termsofaccess(id);
+        ALTER TABLE template ADD COLUMN termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+        ALTER TABLE filemetadata ADD COLUMN termsofuseorlicense_id BIGINT REFERENCES termsofuseorlicense(id);
+
+        UPDATE datasetversion SET termsofaccess_id = termsofuseandaccess_id, default_termsofuseorlicense_id = termsofuseandaccess_id;
+        UPDATE template SET termsofaccess_id = termsofuseandaccess_id, termsofuseorlicense_id = termsofuseandaccess_id;
+
+        ALTER TABLE datasetversion DROP COLUMN termsofuseandaccess_id;
+        ALTER TABLE template DROP COLUMN termsofuseandaccess_id;
+
+        ALTER TABLE datasetversion ALTER COLUMN termsofaccess_id SET NOT NULL;
+        ALTER TABLE datasetversion ALTER COLUMN default_termsofuseorlicense_id SET NOT NULL;
+        ALTER TABLE template ALTER COLUMN termsofaccess_id SET NOT NULL;
+        ALTER TABLE template ALTER COLUMN termsofuseorlicense_id SET NOT NULL;
+
+        DROP TABLE termsofuseandaccess;
+    END IF;
 END
 $$;
-
-GRANT SELECT, INSERT, UPDATE, DELETE ON termsofaccess TO dvnuser;
-GRANT SELECT, INSERT, UPDATE, DELETE ON termsofuseorlicense TO dvnuser;
-GRANT USAGE, SELECT ON SEQUENCE termsofaccess_id_seq TO dvnuser;
-GRANT USAGE, SELECT ON SEQUENCE termsofuseorlicense_id_seq TO dvnuser;


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow custom terms of use or license per file.

**Which issue(s) this PR closes**:

- Closes #

**Special notes for your reviewer**:

**Suggestions on how to test this**:

On the DANS VM  pre-provisioned-dev_dataversenl_v6.9-PATCH-7_2026-03-05.box

- One of:
  - Create a template and a dataset (from the template?) with a restricted file and fill all fields on the terms tab and save the changes for a fresh base box.

        pg_dump --clean -U dvnuser dvndb > /vagrant/shared/DD-2317-file-license-test.sql

  - Repeat the test on a fresh base-box with previously created test datasets:

        psql dvndb < /vagrant/shared/DD-2317-file-license-test.sql 
        curl http://localhost:8080/api/admin/index

- List the content for the table _termsofuseandaccess_.
- As user `postgres`:

      psql --echo-all dvndb < /vagrant/external/dataverse/src/main/resources/db/migration/V6.9.0.1__DD2317-split-termsofuseandaccess.sql

- List the content for the tables _termsofuseorlicense_ and _termsofaccess_.
- A join of these tables should show the same content as the foremer _termsofuseandaccess_.
- Check the changed ID's in the tables _datasetversion_ and _template_.
- The web-UI will show an internal server error when trying to show a dataset.
- [ ] Deploying the war (which requires the PR for DD-2318) causes Flyway to create all tables, what fails because they exist.

      deploy.py --dataverse-war external/dataverse/target/dataverse dev_dataversenl

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

See DD-2318 and beyond.

**Is there a release notes update needed for this change?**:

Idem.

**Additional documentation**:
